### PR TITLE
Adjust onion address size to 96

### DIFF
--- a/src/protocols.csv
+++ b/src/protocols.csv
@@ -11,5 +11,5 @@ hex-code,   dec-code,  size,  name
 0x01E0,     480,       0,     http
 0x01BB,     443,       0,     https
 0x01DD,     477,       0,     ws
-0x01BC,     444,       10,    onion
+0x01BC,     444,       96,    onion
 0x0113,     275,       0,     libp2p-webrtc-star


### PR DESCRIPTION
The onion size is 96: the address 80 and the port number 16 combined. This is what it says in [multiformats/multiaddr's list](https://github.com/multiformats/multiaddr/blob/master/protocols.csv#L13), and [here](https://github.com/multiformats/go-multiaddr/pull/21#issuecomment-236542881) See https://github.com/multiformats/go-multiaddr/pull/21/commits/e32e9cd0f04503aea903905970d9886fd78da524
