### PR TITLE
Add flow type annotations.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+.*/node_modules/documentation/*
+
+[libs]
+
+[include]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "lodash.filter": "^4.6.0",
     "lodash.map": "^4.6.0",
     "varint": "^5.0.0",
-    "xtend": "^4.0.1"
+    "xtend": "^4.0.1",
+    "callback.flow": "^1.0.0"
   },
   "devDependencies": {
     "aegir": "^12.3.0",

--- a/src/codec.js.flow
+++ b/src/codec.js.flow
@@ -1,0 +1,32 @@
+// @flow
+
+import type { Protocol } from "./protocols-table.js"
+
+export type Name$Address = [string, string]
+export type Code$Buffer = [number, Buffer]
+export type { Protocol }
+export class ParseError extends Error {}
+
+declare export default {
+  stringToStringTuples(string): Name$Address[],
+  stringTuplesToString(Name$Address[]): string,
+  tuplesToStringTuples(Code$Buffer[]): Name$Address[],
+  stringTuplesToTuples(Name$Address[]): Code$Buffer[],
+
+  bufferToTuples(Buffer): Code$Buffer[],
+  tuplesToBuffer(Code$Buffer[]): Buffer,
+
+  bufferToString(Buffer): string,
+  stringToBuffer(string): Buffer,
+
+  fromString(string): Buffer,
+  fromBuffer(Buffer): Buffer,
+  validateBuffer(mixed): void,
+  isValidBuffer(mixed): boolean,
+  cleanPath(string): string,
+
+  ParseError(string): ParseError,
+  protoFromTuple(Name$Address | Code$Buffer): Protocol,
+
+  sizeForAddr(Protocol, Buffer): number
+}

--- a/src/convert.js.flow
+++ b/src/convert.js.flow
@@ -1,0 +1,13 @@
+// @flow
+
+import type { Protocol, Code } from "./protocols-table"
+export type { Protocol, Code }
+
+declare export default {
+  // So this just flips the type it seems, I wish there were two different named
+  // functions instead.
+  (Protocol, Buffer): string,
+  (Protocol, string): Buffer,
+  toString(Protocol, Buffer): string,
+  toBuffer(Protocol, string): Buffer
+}

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,49 @@
+// @flow
+
+import type { Callback } from "callback.flow"
+import type { Protocol, Code } from "./protocols-table"
+import protocols from "./protocols-table"
+export opaque type String: string = string
+export type { Protocol, Code, Callback }
+
+export type Options = {
+  family: string,
+  host: string,
+  transport: string,
+  port: string
+}
+
+export type NodeAddress = {
+  family: string,
+  address: string,
+  port: string
+}
+
+export interface Multiaddr {
+  buffer: Buffer;
+  toString(): String;
+  toOptions(): Options;
+  inspect(): string;
+  protos(): Protocol[];
+  protoCodes(): Code[];
+  protoNames(): string[];
+  tuples(): Array<[Code, Buffer]>;
+  stringTuples(): Array<[Code, string | number]>;
+  encapsulate(string | Buffer | Multiaddr): Multiaddr;
+  decapsulate(string | Buffer | Multiaddr): Multiaddr;
+  getPeerId(): ?string;
+  equals(Multiaddr): boolean;
+  nodeAddress(): NodeAddress;
+  isThinWaistAddress(Multiaddr): boolean;
+  fromStupidString(string): empty;
+}
+
+declare export default {
+  Buffer: typeof Buffer,
+  protocols: typeof protocols,
+  (string | Buffer | Multiaddr): Multiaddr,
+  fromNodeAddress(NodeAddress, transport: string): Multiaddr,
+  isMultiaddr(mixed): boolean,
+  isName(mixed): boolean,
+  resolve(mixed, Callback<Error, void>): void
+}

--- a/src/protocols-table.js.flow
+++ b/src/protocols-table.js.flow
@@ -1,0 +1,21 @@
+// @flow
+
+export opaque type Code: number = number
+export type Size = number
+
+export type Protocol = {
+  code: Code,
+  size: Size,
+  name: string,
+  resolvable: boolean
+}
+
+declare export default {
+  (string | number): Protocol,
+  lengthPrefixedVarSize: number,
+  V: number,
+  table: Array<[number, number, string]>,
+  names: { [string]: Protocol },
+  codes: { [number]: Protocol },
+  object(Code, Size, string, boolean): Protocol
+}


### PR DESCRIPTION
As dive into ipfs / libp2p code base I struggle to guess what are all the things passed around. Types as in [flow](http://flow.org/) (or typescript for that matter) simplify learning of how things are connected significantly. There for I decided to contribute type signatures to the code base as I digg through it. 

### What's up with all these .js.flow files ?

Unfortunately flow project has yet to come up with coherent story of how to provide type annotations for third party libraries. In my experience adding `.js.flow` files works best out of all options, that is because flow type checker when gives a precedent to `/path/to/file.js.flow` over `/path/to/file.js` which essentially provides a way to provide type annotations for non-flow typed package such that just using it as dependency will satisfy both type checker and run-time.

It's far from ideal given that `.js` and `.js.flow` files can get out of sync but then again unless you're open to adopt flow this is the best option IMO.

