### PR TITLE
Tighten validation on addr when creating from existing address

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function Multiaddr (addr) {
   }
 
   // default
-  addr = addr || ''
+  addr = addr == null ? '' : addr
 
   if (addr instanceof Buffer) {
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,9 @@ function Multiaddr (addr) {
   }
 
   // default
-  addr = addr == null ? '' : addr
+  if (addr == null) {
+    addr = ''
+  }
 
   if (addr instanceof Buffer) {
     /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -43,6 +43,13 @@ describe('construction', () => {
   it('throws on non string or buffer', () => {
     expect(() => multiaddr({})).to.throw(/addr must be a string/)
   })
+
+  it('throws on falsy non string or buffer', () => {
+    const errRegex = /addr must be a string/
+    expect(() => multiaddr(NaN)).to.throw(errRegex)
+    expect(() => multiaddr(false)).to.throw(errRegex)
+    expect(() => multiaddr(0)).to.throw(errRegex)
+  })
 })
 
 describe('requiring varint', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,8 +40,18 @@ describe('construction', () => {
     expect(multiaddr('').toString()).to.equal('/')
   })
 
-  it('throws on non string or buffer', () => {
-    expect(() => multiaddr({})).to.throw(/addr must be a string/)
+  it('null/undefined construct still works', () => {
+    expect(multiaddr().toString()).to.equal('/')
+    expect(multiaddr(null).toString()).to.equal('/')
+    expect(multiaddr(undefined).toString()).to.equal('/')
+  })
+
+  it('throws on truthy non string or buffer', () => {
+    const errRegex = /addr must be a string/
+    expect(() => multiaddr({})).to.throw(errRegex)
+    expect(() => multiaddr([])).to.throw(errRegex)
+    expect(() => multiaddr(138)).to.throw(errRegex)
+    expect(() => multiaddr(true)).to.throw(errRegex)
   })
 
   it('throws on falsy non string or buffer', () => {


### PR DESCRIPTION
* Throws if `addr` is falsy value such as `0`, `false` or `NaN`
* Allows if `null`, `undefined`, `''`