### PR TITLE
avoid constructor.name pattern

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -415,7 +415,7 @@ Multiaddr.protocols = protocols
  */
 Multiaddr.isMultiaddr = function isMultiaddr (addr) {
   if (addr.constructor && addr.constructor.name) {
-    return addr.constructor.name === 'Multiaddr'
+    return (addr instanceof Multiaddr)
   }
 
   return Boolean(


### PR DESCRIPTION
trying to fix https://github.com/ipfs/js-ipfs/issues/1131 properly.
cc @diasdavid 

Signed-off-by: Yahya <ya7yaz@gmail.com>