### PR TITLE
Revert "avoid constructor.name pattern"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -415,7 +415,7 @@ Multiaddr.protocols = protocols
  */
 Multiaddr.isMultiaddr = function isMultiaddr (addr) {
   if (addr.constructor && addr.constructor.name) {
-    return (addr instanceof Multiaddr)
+    return addr.constructor.name === 'Multiaddr'
   }
 
   return Boolean(


### PR DESCRIPTION
Quoting @dignifiedquire: "there is a reason we don‘t use instanceof anywhere. It breaks for consumers using the library if they bundle a different set of code or the class."

Reverts multiformats/js-multiaddr#55