### PR TITLE
fix: use consistent /dnsaddr code

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -29,9 +29,9 @@ Convert.toString = function convertToString (proto, buf) {
     case 132: // sctp
       return buf2port(buf)
 
-    case 53: // dns
     case 54: // dns4
     case 55: // dns6
+    case 56: // dnsaddr
       return buf2str(buf)
 
     case 421: // ipfs
@@ -54,9 +54,9 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     case 132: // sctp
       return port2buf(parseInt(str, 10))
 
-    case 53: // dns
     case 54: // dns4
     case 55: // dns6
+    case 56: // dnsaddr
       return str2buf(str)
 
     case 421: // ipfs

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -30,9 +30,9 @@ Protocols.table = [
   [17, 16, 'udp'],
   [33, 16, 'dccp'],
   [41, 128, 'ip6'],
-  [53, V, 'dnsaddr', 'resolvable'],
   [54, V, 'dns4', 'resolvable'],
   [55, V, 'dns6', 'resolvable'],
+  [56, V, 'dnsaddr', 'resolvable'],
   [132, 16, 'sctp'],
   // all of the below use varint for size
   [302, 0, 'utp'],


### PR DESCRIPTION
Let's keep 53 reserved for any future /dns protocol. (see multiformats/multiaddr#61). This change is still fine to make at present, because we don't really send these /dnsaddr addresses over the wire anywhere. From what I can tell, there only used in some bootstrap configs.

This change can just go out with the next release any time soon, no particular urgency.