### PR TITLE
Add ip validations to ip addr formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "bs58": "^4.0.1",
     "ip": "^1.1.5",
+    "ip-address": "^5.8.9",
     "lodash.filter": "^4.6.0",
     "lodash.map": "^4.6.0",
     "varint": "^5.0.0",

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const ip = require('ip')
+const ipAddress = require('ip-address')
 const protocols = require('./protocols-table')
 const bs58 = require('bs58')
 const varint = require('varint')
@@ -45,8 +46,9 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
   proto = protocols(proto)
   switch (proto.code) {
     case 4: // ipv4
+      return ip2buf(new ipAddress.Address4(str))
     case 41: // ipv6
-      return ip.toBuffer(str)
+      return ip2buf(new ipAddress.Address6(str))
 
     case 6: // tcp
     case 17: // udp
@@ -64,6 +66,11 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     default:
       return Buffer.from(str, 'hex') // no clue. convert from hex
   }
+}
+
+function ip2buf (ipaddr) {
+  if (!ipaddr.isValid()) throw new Error('invalid ip address')
+  return ip.toBuffer(ipaddr.address)
 }
 
 function port2buf (port) {

--- a/test/convert.spec.js
+++ b/test/convert.spec.js
@@ -8,7 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 describe('convert', () => {
-  it('handles buffers', () => {
+  it('handles ip4 buffers', () => {
     expect(
       convert('ip4', Buffer.from('c0a80001', 'hex'))
     ).to.eql(
@@ -16,11 +16,43 @@ describe('convert', () => {
     )
   })
 
-  it('handles strings', () => {
+  it('handles ip6 buffers', () => {
+    expect(
+      convert('ip6', Buffer.from('abcd0000000100020003000400050006', 'hex'))
+    ).to.eql(
+      'abcd:0:1:2:3:4:5:6'
+    )
+  })
+
+  it('handles ipv6 strings', () => {
+    expect(
+      convert('ip6', 'ABCD::1:2:3:4:5:6')
+    ).to.eql(
+      Buffer.from('ABCD0000000100020003000400050006', 'hex')
+    )
+  })
+
+  it('handles ip4 strings', () => {
     expect(
       convert('ip4', '192.168.0.1')
     ).to.eql(
       Buffer.from('c0a80001', 'hex')
+    )
+  })
+
+  it('throws on invalid ip4 conversion', () => {
+    expect(
+      () => convert('ip4', '555.168.0.1')
+    ).to.throw(
+      /invalid ip address/
+    )
+  })
+
+  it('throws on invalid ip6 conversion', () => {
+    expect(
+      () => convert('ip6', 'FFFF::GGGG')
+    ).to.throw(
+      /invalid ip address/
     )
   })
 


### PR DESCRIPTION
The PR here addresses ip validation issue with ip based js multiaddr #58. 
The existing behavior translates invalid ip addresses to valid ip addresses, and throws on some invalid ip addresses, but not all. 

This patch includes ip-address package which is already apart of js-libp2p-switch to validate ip addresses prior to translating them to and from String to Buffer.  