### PR TITLE
feat: use class-is module for type checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/multiformats/js-multiaddr",
   "dependencies": {
     "bs58": "^4.0.1",
+    "class-is": "^0.5.0",
     "ip": "^1.1.5",
     "lodash.filter": "^4.6.0",
     "lodash.map": "^4.6.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,9 @@ const codec = require('./codec')
 const protocols = require('./protocols-table')
 const varint = require('varint')
 const bs58 = require('bs58')
+const withIs = require('class-is')
 
 const NotImplemented = new Error('Sorry, Not Implemented Yet.')
-
-exports = module.exports = Multiaddr
 
 /**
  * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
@@ -22,7 +21,7 @@ exports = module.exports = Multiaddr
  * Multiaddr('/ip4/127.0.0.1/tcp/4001')
  * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
  */
-function Multiaddr (addr) {
+const Multiaddr = withIs.proto(function (addr) {
   if (!(this instanceof Multiaddr)) {
     return new Multiaddr(addr)
   }
@@ -44,7 +43,7 @@ function Multiaddr (addr) {
   } else {
     throw new Error('addr must be a string, Buffer, or another Multiaddr')
   }
-}
+}, { className: 'Multiaddr', symbolName: '@multiformats/js-multiaddr/multiaddr' })
 
 /**
  * Returns Multiaddr as a String
@@ -403,28 +402,6 @@ Multiaddr.prototype.fromStupidString = function fromStupidString (str) {
 Multiaddr.protocols = protocols
 
 /**
- * Returns if something is a Multiaddr or not
- *
- * @param {Multiaddr} addr
- * @return {Bool} isMultiaddr
- * @example
- * Multiaddr.isMultiaddr(Multiaddr('/ip4/127.0.0.1/tcp/4001'))
- * // true
- * Multiaddr.isMultiaddr('/ip4/127.0.0.1/tcp/4001')
- * // false
- */
-Multiaddr.isMultiaddr = function isMultiaddr (addr) {
-  if (addr.constructor && addr.constructor.name) {
-    return addr.constructor.name === 'Multiaddr'
-  }
-
-  return Boolean(
-    addr.fromStupidString &&
-    addr.protos
-  )
-}
-
-/**
  * Returns if something is a Multiaddr that is a name
  *
  * @param {Multiaddr} addr
@@ -459,3 +436,5 @@ Multiaddr.resolve = function resolve (addr, callback) {
    */
   return callback(new Error('not implemented yet'))
 }
+
+exports = module.exports = Multiaddr


### PR DESCRIPTION
This is an ongoing effort to fix the https://github.com/ipfs/js-ipfs/issues/938 issue.

It uses a module I've published that abstracts this solution: https://github.com/ipfs/js-ipfs/issues/1131#issuecomment-373299739.