### PR TITLE
Add p2p protocol support

### DIFF
--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -37,6 +37,8 @@ Protocols.table = [
   // all of the below use varint for size
   [302, 0, 'utp'],
   [421, Protocols.lengthPrefixedVarSize, 'ipfs'],
+  // preferred name for 421 (added below ipfs, p2p takes precedence during table population)
+  [421, Protocols.lengthPrefixedVarSize, 'p2p'],
   [480, 0, 'http'],
   [443, 0, 'https'],
   [460, 0, 'quic'],

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -211,15 +211,15 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
-  it('ip4 + ipfs', () => {
-    const str = '/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
+  it('ip4 + p2p', () => {
+    const str = '/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
-  it('ip6 + ipfs', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
+  it('ip6 + p2p', () => {
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -288,43 +288,43 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
-  it('ip6 + tcp + websockets + ipfs', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+  it('ip6 + tcp + websockets + p2p', () => {
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
-  it('ip6 + udp + quic + ipfs', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+  it('ip6 + udp + quic + p2p', () => {
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
-  it('ipfs', () => {
-    const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+  it('p2p', () => {
+    const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-circuit', () => {
-    const str = '/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
-  it('p2p-circuit ipfs', () => {
-    const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
+  it('p2p-circuit p2p', () => {
+    const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-webrtc-star', () => {
-    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -381,7 +381,7 @@ describe('helpers', () => {
         }])
     })
 
-    it('works with ipfs', () => {
+    it('works with ipfs/p2p', () => {
       expect(
         multiaddr('/ip4/0.0.0.0/utp/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
       ).to.be.eql([{
@@ -396,7 +396,7 @@ describe('helpers', () => {
         resolvable: false
       }, {
         code: 421,
-        name: 'ipfs',
+        name: 'p2p',
         size: -1,
         resolvable: false
       }])
@@ -588,7 +588,7 @@ describe('helpers', () => {
   describe('.getPeerId should parse id from multiaddr', () => {
     it('parses extracts the peer Id from a multiaddr', () => {
       expect(
-        multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+        multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
   })


### PR DESCRIPTION
This is needed so that we can switch to using `p2p` instead of `ipfs` by default.

Replaces #69, this just rebases that and updates tests from the latest master changes.
Closes #68.