### PR TITLE
fix: make ipfs the default 421 proto name

### DIFF
--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -36,9 +36,11 @@ Protocols.table = [
   [132, 16, 'sctp'],
   // all of the below use varint for size
   [302, 0, 'utp'],
-  [421, Protocols.lengthPrefixedVarSize, 'ipfs'],
-  // preferred name for 421 (added below ipfs, p2p takes precedence during table population)
   [421, Protocols.lengthPrefixedVarSize, 'p2p'],
+  // preferred name for 421 (added below p2p, ipfs takes precedence during table population)
+  // this enables us to support p2p but allow for better backwards support of ipfs multiaddrs
+  // while migration happens to using p2p as the default
+  [421, Protocols.lengthPrefixedVarSize, 'ipfs'],
   [480, 0, 'http'],
   [443, 0, 'https'],
   [460, 0, 'quic'],

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -36,10 +36,12 @@ Protocols.table = [
   [132, 16, 'sctp'],
   // all of the below use varint for size
   [302, 0, 'utp'],
+  // `p2p` is the preferred name for 421
   [421, Protocols.lengthPrefixedVarSize, 'p2p'],
-  // preferred name for 421 (added below p2p, ipfs takes precedence during table population)
-  // this enables us to support p2p but allow for better backwards support of ipfs multiaddrs
-  // while migration happens to using p2p as the default
+  // `ipfs` has been added after `p2p` so that it is used by default.
+  // The reason for this is to provide better backwards support for
+  // code bases that do not yet support the `p2p` proto name. Eventually
+  // `p2p` should become the default.
   [421, Protocols.lengthPrefixedVarSize, 'ipfs'],
   [480, 0, 'http'],
   [443, 0, 'https'],

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -215,6 +215,13 @@ describe('variants', () => {
     const str = '/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+  })
+
+  it('ip4 + ipfs', () => {
+    const str = '/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
@@ -222,7 +229,7 @@ describe('variants', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str)
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
   })
 
   it.skip('ip4 + dccp', () => {})
@@ -288,8 +295,22 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
+  it('ip6 + tcp + websockets + ipfs', () => {
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str)
+  })
+
   it('ip6 + tcp + websockets + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+  })
+
+  it('ip6 + udp + quic + ipfs', () => {
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -299,11 +320,18 @@ describe('variants', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str)
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
   })
 
   it('p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+  })
+
+  it('ipfs', () => {
+    const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -313,11 +341,18 @@ describe('variants', () => {
     const str = '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str)
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
   })
 
   it('p2p-circuit p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+  })
+
+  it('p2p-circuit ipfs', () => {
+    const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -325,6 +360,13 @@ describe('variants', () => {
 
   it('p2p-webrtc-star', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+  })
+
+  it('p2p-webrtc-star ipfs', () => {
+    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -381,7 +423,7 @@ describe('helpers', () => {
         }])
     })
 
-    it('works with ipfs/p2p', () => {
+    it('works with ipfs', () => {
       expect(
         multiaddr('/ip4/0.0.0.0/utp/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
       ).to.be.eql([{
@@ -396,7 +438,28 @@ describe('helpers', () => {
         resolvable: false
       }, {
         code: 421,
-        name: 'p2p',
+        name: 'ipfs',
+        size: -1,
+        resolvable: false
+      }])
+    })
+
+    it('works with p2p', () => {
+      expect(
+        multiaddr('/ip4/0.0.0.0/utp/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
+      ).to.be.eql([{
+        code: 4,
+        name: 'ip4',
+        size: 32,
+        resolvable: false
+      }, {
+        code: 302,
+        name: 'utp',
+        size: 0,
+        resolvable: false
+      }, {
+        code: 421,
+        name: 'ipfs',
         size: -1,
         resolvable: false
       }])
@@ -586,9 +649,14 @@ describe('helpers', () => {
   })
 
   describe('.getPeerId should parse id from multiaddr', () => {
-    it('parses extracts the peer Id from a multiaddr', () => {
+    it('parses extracts the peer Id from a multiaddr, p2p', () => {
       expect(
         multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+      ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+    })
+    it('parses extracts the peer Id from a multiaddr, ipfs', () => {
+      expect(
+        multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -215,7 +215,7 @@ describe('variants', () => {
     const str = '/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('ip4 + ipfs', () => {
@@ -229,7 +229,7 @@ describe('variants', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it.skip('ip4 + dccp', () => {})
@@ -306,7 +306,7 @@ describe('variants', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('ip6 + udp + quic + ipfs', () => {
@@ -320,14 +320,14 @@ describe('variants', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('ipfs', () => {
@@ -341,14 +341,14 @@ describe('variants', () => {
     const str = '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('p2p-circuit p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('p2p-circuit ipfs', () => {
@@ -362,7 +362,7 @@ describe('variants', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
-    expect(addr.toString()).to.equal(str.replace('/p2p/','/ipfs/'))
+    expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('p2p-webrtc-star ipfs', () => {


### PR DESCRIPTION
This corrects an issue with the order of the protocol table. Previously p2p was set last in the order, which caused all created multiaddr's to use p2p instead of ipfs. While `p2p` is the desired protocol name, this helps better support legacy systems that will not yet have support for p2p.

Eventually, `p2p` should be transitioned to the default.

I've updated the test suite to account for p2p and ipfs protocol checks. They verify that created multiaddr's will always use ipfs instead of p2p.

Reference https://github.com/multiformats/js-multiaddr/pull/76#issuecomment-447945684