### PR TITLE
feat: Add /p2p-stardust

### DIFF
--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -47,6 +47,7 @@ Protocols.table = [
   [477, 0, 'ws'],
   [478, 0, 'wss'],
   [479, 0, 'p2p-websocket-star'],
+  [277, 0, 'p2p-stardust'],
   [275, 0, 'p2p-webrtc-star'],
   [276, 0, 'p2p-webrtc-direct'],
   [290, 0, 'p2p-circuit']


### PR DESCRIPTION
This is part of the endeavor to replace ws-star with the newly created stardust protocol. See libp2p/js-libp2p-websocket-star#70 for a reference