### PR TITLE
chore: remove unimplemented fromStupidString

### DIFF
--- a/examples/try.js
+++ b/examples/try.js
@@ -15,7 +15,6 @@ log(addr.protos())
 
 log(addr.nodeAddress())
 log(multiaddr.fromNodeAddress(addr.nodeAddress(), 'udp'))
-// addr = multiaddr.fromStupidString("udp4://127.0.0.1:1234")
 
 log(addr.encapsulate('/sctp/5678'))
 log(addr.decapsulate('/udp'))

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@ const varint = require('varint')
 const bs58 = require('bs58')
 const withIs = require('class-is')
 
-const NotImplemented = new Error('Sorry, Not Implemented Yet.')
-
 /**
  * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
  * a Buffer, String or another Multiaddr instance
@@ -369,25 +367,6 @@ Multiaddr.prototype.isThinWaistAddress = function isThinWaistAddress (addr) {
     return false
   }
   return true
-}
-
-// TODO rename this to something else than "stupid string"
-/**
- * Converts a "stupid string" into a Multiaddr.
- *
- * Stupid string format:
- * ```
- * <proto><IPv>://<IP Addr>[:<proto port>]
- * udp4://1.2.3.4:5678
- * ```
- *
- * @param {String} [str] - String in the "stupid" format
- * @throws {NotImplemented}
- * @returns {undefined}
- * @todo Not Implemented yet
- */
-Multiaddr.prototype.fromStupidString = function fromStupidString (str) {
-  throw NotImplemented
 }
 
 /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -642,12 +642,6 @@ describe('helpers', () => {
     })
   })
 
-  describe('.fromStupidString', () => {
-    it('parses an address in the format <proto><IPv>://<IP Addr>[:<proto port>]', () => {
-      expect(() => multiaddr('/').fromStupidString()).to.throw(/Not Implemented/)
-    })
-  })
-
   describe('.getPeerId should parse id from multiaddr', () => {
     it('parses extracts the peer Id from a multiaddr, p2p', () => {
       expect(


### PR DESCRIPTION
There are no longer any references to fromStupidString in the multiaddr and go-multiaddr repos, and it's always been a needlesly inflamtory method name.

This PR remove is and the test that checked it was unimplemented.

There are efforts to provide encoding and decoding between multiaddrs and uris in

- https://github.com/tableflip/multiaddr-to-uri
- https://github.com/tableflip/uri-to-multiaddr


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>