### PR TITLE
chore: Make @jacobheun the lead maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ js-multiaddr
 
 ## Lead Maintainer
 
-[Victor Bjelkholm](https://github.com/VictorBjelkholm)
+[Jacob Heun](https://github.com/jacobheun)
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "multiaddr",
   "version": "6.0.4",
   "description": "multiaddr implementation (binary + string representation of network addresses)",
-  "leadMaintainer": "Victor Bjelkholm <victorbjelkholm@gmail.com>",
+  "leadMaintainer": "Jacob Heun <jacobheun@gmail.com>",
   "main": "src/index.js",
   "scripts": {
     "lint": "aegir lint",


### PR DESCRIPTION
I think it would make sense to hand the lead maintainership over to someone from the libp2p team, I propose @jacobheun.

What do you think @victorb?

Once approved my @victorb (current lead maintainer) and @daviddias (tech lead) I'll add jacob as maintainer to npm and will remove myself.