### PR TITLE
add unix protocol support

### DIFF
--- a/src/codec.js
+++ b/src/codec.js
@@ -52,6 +52,18 @@ function stringToStringTuples (str) {
       throw ParseError('invalid address: ' + str)
     }
 
+    // if it's a path proto, take the rest
+    if (proto.path) {
+      tuples.push([
+        part,
+        // TODO: should we need to check each path part to see if it's a proto?
+        // This would allow for other protocols to be added after a unix path,
+        // however it would have issues if the path had a protocol name in the path
+        cleanPath(parts.slice(p).join('/'))
+      ])
+      break
+    }
+
     tuples.push([part, parts[p]])
   }
 
@@ -69,7 +81,7 @@ function stringTuplesToString (tuples) {
     }
   })
 
-  return '/' + parts.join('/')
+  return cleanPath(parts.join('/'))
 }
 
 // [[str name, str addr]... ] -> [[int code, Buffer]... ]

--- a/src/convert.js
+++ b/src/convert.js
@@ -30,9 +30,11 @@ Convert.toString = function convertToString (proto, buf) {
     case 132: // sctp
       return buf2port(buf)
 
+    case 53: // dns
     case 54: // dns4
     case 55: // dns6
     case 56: // dnsaddr
+    case 400: // unix
       return buf2str(buf)
 
     case 421: // ipfs
@@ -56,9 +58,11 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     case 132: // sctp
       return port2buf(parseInt(str, 10))
 
+    case 53: // dns
     case 54: // dns4
     case 55: // dns6
     case 56: // dnsaddr
+    case 400: // unix
       return str2buf(str)
 
     case 421: // ipfs

--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,6 @@ Multiaddr.prototype.getPath = function getPath () {
         return true
       }
     })[0][1]
-
   } catch (e) {
     path = null
   }

--- a/src/index.js
+++ b/src/index.js
@@ -256,6 +256,34 @@ Multiaddr.prototype.getPeerId = function getPeerId () {
 }
 
 /**
+ * Extract the path if the multiaddr contains one
+ *
+ * @return {String|null} path - The path of the multiaddr, or null if no path protocol is present
+ * @example
+ * const mh1 = Multiaddr('/ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock')
+ * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock>
+ *
+ * // should return utf8 string or null if the id is missing or invalid
+ * const path = mh1.getPath()
+ */
+Multiaddr.prototype.getPath = function getPath () {
+  let path = null
+  try {
+    path = this.stringTuples().filter((tuple) => {
+      const proto = protocols(tuple[0])
+      if (proto.path) {
+        return true
+      }
+    })[0][1]
+
+  } catch (e) {
+    path = null
+  }
+
+  return path
+}
+
+/**
  * Checks if two Multiaddrs are the same
  *
  * @param {Multiaddr} addr

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -40,7 +40,7 @@ Protocols.table = [
   [290, 0, 'p2p-circuit'],
   [301, 0, 'udt'],
   [302, 0, 'utp'],
-  [400, V, 'unix'],
+  [400, V, 'unix', false, 'path'],
   // `p2p` is the preferred name for 421
   [421, V, 'p2p'],
   // `ipfs` has been added after `p2p` so that it is used by default.
@@ -71,12 +71,13 @@ Protocols.table.map(row => {
 
 Protocols.object = p
 
-function p (code, size, name, resolvable) {
+function p (code, size, name, resolvable, path) {
   return {
     code: code,
     size: size,
     name: name,
-    resolvable: Boolean(resolvable)
+    resolvable: Boolean(resolvable),
+    path: Boolean(path)
   }
 }
 

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -25,32 +25,38 @@ Protocols.V = V
 Protocols.table = [
   [4, 32, 'ip4'],
   [6, 16, 'tcp'],
-  [273, 16, 'udp'],
   [33, 16, 'dccp'],
   [41, 128, 'ip6'],
+  [42, V, 'ip6zone'],
+  [53, V, 'dns', 'resolvable'],
   [54, V, 'dns4', 'resolvable'],
   [55, V, 'dns6', 'resolvable'],
   [56, V, 'dnsaddr', 'resolvable'],
   [132, 16, 'sctp'],
-  // all of the below use varint for size
+  [273, 16, 'udp'],
+  [275, 0, 'p2p-webrtc-star'],
+  [276, 0, 'p2p-webrtc-direct'],
+  [277, 0, 'p2p-stardust'],
+  [290, 0, 'p2p-circuit'],
+  [301, 0, 'udt'],
   [302, 0, 'utp'],
+  [400, V, 'unix'],
   // `p2p` is the preferred name for 421
-  [421, Protocols.lengthPrefixedVarSize, 'p2p'],
+  [421, V, 'p2p'],
   // `ipfs` has been added after `p2p` so that it is used by default.
   // The reason for this is to provide better backwards support for
   // code bases that do not yet support the `p2p` proto name. Eventually
   // `p2p` should become the default.
-  [421, Protocols.lengthPrefixedVarSize, 'ipfs'],
-  [480, 0, 'http'],
+  [421, V, 'ipfs'],
   [443, 0, 'https'],
+  [444, 96, 'onion'],
+  [445, 296, 'onion3'],
+  [446, V, 'garlic64'],
   [460, 0, 'quic'],
   [477, 0, 'ws'],
   [478, 0, 'wss'],
   [479, 0, 'p2p-websocket-star'],
-  [277, 0, 'p2p-stardust'],
-  [275, 0, 'p2p-webrtc-star'],
-  [276, 0, 'p2p-webrtc-direct'],
-  [290, 0, 'p2p-circuit']
+  [480, 0, 'http']
 ]
 
 Protocols.names = {}


### PR DESCRIPTION
This also updates the protocol table to match the latest at [multiaddr/protocols.csv](https://github.com/multiformats/multiaddr/blob/f3bb08e27b81523d1f1f0371eb1800395b98922d/protocols.csv)

resolves https://github.com/multiformats/js-multiaddr/issues/82