### PR TITLE
fix: JSON round trip works as expected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ Multiaddr.prototype.toString = function toString () {
  * JSON.stringify(Multiaddr('/ip4/127.0.0.1/tcp/4001'))
  * // '/ip4/127.0.0.1/tcp/4001'
  */
-Multiaddr.prototype.toJSON = Multiaddr.prototype.toString;
+Multiaddr.prototype.toJSON = Multiaddr.prototype.toString
 
 /**
  * Returns Multiaddr as a convinient options object to be used with net.createConnection

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,16 @@ Multiaddr.prototype.toString = function toString () {
 }
 
 /**
+ * Returns Multiaddr as a JSON encoded object
+ *
+ * @returns {String}
+ * @example
+ * JSON.stringify(Multiaddr('/ip4/127.0.0.1/tcp/4001'))
+ * // '/ip4/127.0.0.1/tcp/4001'
+ */
+Multiaddr.prototype.toJSON = Multiaddr.prototype.toString;
+
+/**
  * Returns Multiaddr as a convinient options object to be used with net.createConnection
  *
  * @returns {{family: String, host: String, transport: String, port: String}}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -36,6 +36,11 @@ describe('construction', () => {
     expect(multiaddr(udpAddr).buffer).to.deep.equal(udpAddr.buffer)
   })
 
+  it('reconstruct with JSON', () => {
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).buffer === udpAddr.buffer).to.equal(false)
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).buffer).to.deep.equal(udpAddr.buffer)
+  })
+
   it('empty construct still works', () => {
     expect(multiaddr('').toString()).to.equal('/')
   })


### PR DESCRIPTION
Fix for #54

Adds a test case, and simply reuses the `toString` implementation.