### PR TITLE
Changed websocket [secure] to endpoint selection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
     "Hugo Dias <hugomrdias@gmail.com>",
     "Jacob Heun <jacobheun@gmail.com>",
+    "Jorropo <jorropo.pgm@gmail.com>",
     "Juan Batiz-Benet <juan@benet.ai>",
     "Lars Gierth <lgierth@users.noreply.github.com>",
     "Maciej Krüger <mkg20001@gmail.com>",

--- a/src/convert.js
+++ b/src/convert.js
@@ -36,6 +36,8 @@ Convert.toString = function convertToString (proto, buf) {
     case 55: // dns6
     case 56: // dnsaddr
     case 400: // unix
+    case 477: // websocket
+    case 478: // websocket secure
       return buf2str(buf)
 
     case 421: // ipfs
@@ -68,6 +70,8 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     case 55: // dns6
     case 56: // dnsaddr
     case 400: // unix
+    case 477: // websocket
+    case 478: // websocket secure
       return str2buf(str)
 
     case 421: // ipfs

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -53,8 +53,8 @@ Protocols.table = [
   [445, 296, 'onion3'],
   [446, V, 'garlic64'],
   [460, 0, 'quic'],
-  [477, 0, 'ws'],
-  [478, 0, 'wss'],
+  [477, V, 'ws'],
+  [478, V, 'wss'],
   [479, 0, 'p2p-websocket-star'],
   [480, 0, 'http']
 ]

--- a/test/convert.spec.js
+++ b/test/convert.spec.js
@@ -59,7 +59,7 @@ describe('convert', () => {
   describe('.toBuffer', () => {
     it('defaults to hex conversion', () => {
       expect(
-        convert.toBuffer('ws', 'c0a80001')
+        convert.toBuffer('p2p-webrtc-star', 'c0a80001')
       ).to.eql(
         Buffer.from([192, 168, 0, 1])
       )
@@ -78,7 +78,7 @@ describe('convert', () => {
 
     it('defaults to hex conversion', () => {
       expect(
-        convert.toString('ws', Buffer.from([192, 168, 0, 1]))
+        convert.toString('p2p-webrtc-star', Buffer.from([192, 168, 0, 1]))
       ).to.eql(
         'c0a80001'
       )

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -127,7 +127,7 @@ describe('manipulation', () => {
     const ipfsAddr = multiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     const ip6Addr = multiaddr('/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095')
     const tcpAddr = multiaddr('/tcp/8000')
-    const webAddr = multiaddr('/ws')
+    const webAddr = multiaddr('/ws/libp2pEndpoint')
 
     expect(
       multiaddr('/')
@@ -301,28 +301,28 @@ describe('variants', () => {
   })
 
   it('ip4 + tcp + websockets', () => {
-    const str = '/ip4/127.0.0.1/tcp/8000/ws'
+    const str = '/ip4/127.0.0.1/tcp/8000/ws/libp2pEndpoint'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws'
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/libp2pEndpoint'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets + ipfs', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/libp2pEndpoint/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets + p2p', () => {
-    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/libp2pEndpoint/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
@@ -429,14 +429,14 @@ describe('variants', () => {
   })
 
   it('p2p-webrtc-star', () => {
-    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/ip4/127.0.0.1/tcp/9090/ws/meetPoint/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str.replace('/p2p/', '/ipfs/'))
   })
 
   it('p2p-webrtc-star ipfs', () => {
-    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const str = '/ip4/127.0.0.1/tcp/9090/ws/meetPoint/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
@@ -450,7 +450,7 @@ describe('variants', () => {
   })
 
   it('p2p-websocket-star', () => {
-    const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star'
+    const str = '/ip4/127.0.0.1/tcp/9090/ws/meetPoint/p2p-websocket-star'
     const addr = multiaddr(str)
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)


### PR DESCRIPTION
This is for be compatible with libp2p/go-ws-transport#48 to allow websocket secure to be served under a real website (with reverse proxy) to go-libp2p.

## To do:
- [X] make ws transport compatible libp2p/js-libp2p-websockets#86
- [ ] make p2p-websocket-star transport compatible
- [ ] make p2p-webrtc-star transport compatible
- [X]  make multiaddr-to-uri compatible tableflip/multiaddr-to-uri#4