### PR TITLE
Add ZeroNet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "David Dias <daviddias.p@gmail.com>",
     "Diogo Silva <fsdiogo@gmail.com>",
     "Dmitriy Ryajov <dryajov@gmail.com>",
+    "Filip Š <projects@filips.si>",
     "Friedel Ziegelmayer <dignifiedquire@gmail.com>",
     "Hugo Dias <hugomrdias@gmail.com>",
     "Jacob Heun <jacobheun@gmail.com>",

--- a/src/convert.js
+++ b/src/convert.js
@@ -79,7 +79,7 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     case 445: // onion3
       return onion32buf(str)
     case 4096: // zeronet
-      return zeronet2buf(buf)
+      return zeronet2buf(str)
     default:
       return Buffer.from(str, 'hex') // no clue. convert from hex
   }

--- a/src/convert.js
+++ b/src/convert.js
@@ -44,6 +44,8 @@ Convert.toString = function convertToString (proto, buf) {
       return buf2onion(buf)
     case 445: // onion3
       return buf2onion(buf)
+    case 4096: // zeronet
+      return buf2zeronet(buf)
     default:
       return buf.toString('hex') // no clue. convert to hex
   }
@@ -76,6 +78,8 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
       return onion2buf(str)
     case 445: // onion3
       return onion32buf(str)
+    case 4096: // zeronet
+      return zeronet2buf(buf)
     default:
       return Buffer.from(str, 'hex') // no clue. convert from hex
   }
@@ -185,4 +189,22 @@ function buf2onion (buf) {
   const addr = base32.encode(addrBytes).toString('ascii').toLowerCase()
   const port = buf2port(portBytes)
   return addr + ':' + port
+}
+
+function zeronet2buf (hash) {
+  const mh = Buffer.from(bs58.decode(hash))
+  const size = Buffer.from(varint.encode(mh.length))
+
+  return Buffer.concat([size, mh])
+}
+
+function buf2zeronet (buf) {
+  const size = varint.decode(buf)
+  const address = buf.slice(varint.decode.bytes)
+
+  if (address.length !== size) {
+    throw new Error('inconsistent lengths')
+  }
+
+  return bs58.encode(address)
 }

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -56,7 +56,8 @@ Protocols.table = [
   [477, 0, 'ws'],
   [478, 0, 'wss'],
   [479, 0, 'p2p-websocket-star'],
-  [480, 0, 'http']
+  [480, 0, 'http'],
+  [4096, V, 'zeronet']
 ]
 
 Protocols.names = {}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -455,6 +455,13 @@ describe('variants', () => {
     expect(addr).to.have.property('buffer')
     expect(addr.toString()).to.equal(str)
   })
+
+  it('zeronet', () => {
+    const str = '/zeronet/1HeLLo4uzjaLetFx6NH3PMwFP3qbRbTf3D'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal(str)
+  })
 })
 
 describe('helpers', () => {


### PR DESCRIPTION
Add support for [ZeroNet](https://zeronet.io/) site adddress. ZeroNet uses old-style Bitcoin addresses as site addresses.

Also see multiformats/multicodec#140.