### PR TITLE
fix: make getPeerId resolve the last id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,11 +251,14 @@ Multiaddr.prototype.decapsulate = function decapsulate (addr) {
 Multiaddr.prototype.getPeerId = function getPeerId () {
   let b58str = null
   try {
-    b58str = this.stringTuples().filter((tuple) => {
+    const tuples = this.stringTuples().filter((tuple) => {
       if (tuple[0] === protocols.names.ipfs.code) {
         return true
       }
-    })[0][1]
+    })
+
+    // Get the last id
+    b58str = tuples.pop()[1]
 
     bs58.decode(b58str)
   } catch (e) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -750,6 +750,11 @@ describe('helpers', () => {
         multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
+    it('extracts the correct peer Id from a circuit multiaddr', () => {
+      expect(
+        multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+      ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+    })
     it('parses extracts the peer Id from a multiaddr, ipfs', () => {
       expect(
         multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()


### PR DESCRIPTION
Currently `getPeerId` returns the first PeerId in the multiaddr. For most addresses this is fine. However, if a node is using a relay as an entrypoint, such as nodes running AutoRelay, getPeerId returns the id of the relay and not the destination peer.

For example the multiaddr, `/ip4/0.0.0.0/tcp/8080/p2p/QmRelay/p2p-circuit/p2p/QmTarget`, indicates that the target peer `QmTarget` is dialable over the relay peer `QmRelay`. Running `getPeerId` resolves `QmRelay` instead of `QmTarget`. The last peer id in the address should always be the target peer.