### PR TITLE
refactor: use async instead of callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "bs58": "^4.0.1",
     "class-is": "^1.1.0",
     "ip": "^1.1.5",
-    "is-ip": "^2.0.0",
+    "is-ip": "^3.1.0",
     "varint": "^5.0.0",
     "hi-base32": "~0.5.0"
   },
   "devDependencies": {
-    "aegir": "^18.2.0",
-    "bundlesize": "~0.17.0",
+    "aegir": "^20.0.0",
+    "bundlesize": "~0.18.0",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -440,14 +440,13 @@ Multiaddr.isName = function isName (addr) {
 /**
  * Returns an array of multiaddrs, by resolving the multiaddr that is a name
  *
+ * @async
  * @param {Multiaddr} addr
- *
- * @param {Function} callback
- * @return {Bool} isName
+ * @return {Multiaddr[]}
  */
-Multiaddr.resolve = function resolve (addr, callback) {
+Multiaddr.resolve = function resolve (addr) {
   if (!Multiaddr.isMultiaddr(addr) || !Multiaddr.isName(addr)) {
-    return callback(new Error('not a valid name'))
+    return Promise.reject(Error('not a valid name'))
   }
 
   /*
@@ -455,7 +454,7 @@ Multiaddr.resolve = function resolve (addr, callback) {
    *   - what to return
    *   - how to achieve it in the browser?
    */
-  return callback(new Error('not implemented yet'))
+  return Promise.reject(new Error('not implemented yet'))
 }
 
 exports = module.exports = Multiaddr

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -835,14 +835,16 @@ describe('helpers', () => {
 
     describe('.resolve', () => {
       it.skip('valid and active DNS name', (done) => {})
-      it.skip('valid but inactive DNS name', (done) => {})
-      it('invalid DNS name', (done) => {
+      it.skip('valid but inactive DNS name', () => {})
+      it('invalid DNS name', () => {
         const str = '/ip4/127.0.0.1'
         const addr = multiaddr(str)
-        multiaddr.resolve(addr, (err, multiaddrs) => {
-          expect(err).to.exist()
-          done()
-        })
+
+        return multiaddr.resolve(addr)
+          .then(expect.fail, (err) => {
+            expect(err).to.exist()
+            expect(err.message).to.eql('not a valid name')
+          })
       })
     })
   })


### PR DESCRIPTION
While `resolve` is still not yet implemented, this migrates the function away from callbacks. Multiaddr needs a major version release due to #87 changing ports from strings to numbers. While most JS implementations shouldn't have issues, test suites might, and Typescript implementations probably will. As such, I wanted to get this update in that release. While nobody should be using this function as it's not yet implemented, migrating away from callbacks is still technically a breaking change. Once it's implemented, it can just be a minor version update.

When implemented, the function will need to be async and should return a list of multiaddrs, so the footprint won't need to change.

