### PR TITLE
feat: add decapsulateCode method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -238,6 +238,34 @@ Multiaddr.prototype.decapsulate = function decapsulate (addr) {
 }
 
 /**
+ * A more reliable version of `decapsulate` if you are targeting a
+ * specific code, such as 421 (this /p2p code). The last index of the code
+ * will be removed from the `Multiaddr`, and a new instance will be returned.
+ * If the code is not present, the original `Multiaddr` is returned.
+ *
+ * @param {Number} code The code of the protocol to decapsulate from this Multiaddr
+ * @return {Multiaddr}
+ * @example
+ * const addr = Multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+ * // <Multiaddr 0400... - /ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC>
+ *
+ * addr.decapsulateCode(421).toString()
+ * // '/ip4/0.0.0.0/tcp/8080'
+ *
+ * Multiaddr('/ip4/127.0.0.1/tcp/8080').decapsulateCode(421).toString()
+ * // '/ip4/127.0.0.1/tcp/8080'
+ */
+Multiaddr.prototype.decapsulateCode = function decapsulateCode (code) {
+  const tuples = this.tuples()
+  for (let i = tuples.length - 1; i >= 0; i--) {
+    if (tuples[i][0] === code) {
+      return Multiaddr(codec.tuplesToBuffer(tuples.slice(0, i)))
+    }
+  }
+  return this
+}
+
+/**
  * Extract the peerId if the multiaddr contains one
  *
  * @return {String|null} peerId - The id of the peer or null if invalid or missing from the ma

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,7 @@ Multiaddr.prototype.decapsulate = function decapsulate (addr) {
 
 /**
  * A more reliable version of `decapsulate` if you are targeting a
- * specific code, such as 421 (this /p2p code). The last index of the code
+ * specific code, such as 421 (the `p2p` protocol code). The last index of the code
  * will be removed from the `Multiaddr`, and a new instance will be returned.
  * If the code is not present, the original `Multiaddr` is returned.
  *

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -598,6 +598,22 @@ describe('helpers', () => {
     })
   })
 
+  describe('.decapsulateCode', () => {
+    it('removes the last occurrence of the code from the multiaddr', () => {
+      const relayTCP = multiaddr('/ip4/0.0.0.0/tcp/8080')
+      const relay = relayTCP.encapsulate('/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit')
+      const target = multiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+      const original = relay.encapsulate(target)
+      expect(original.decapsulateCode(421)).to.eql(relay)
+      expect(relay.decapsulateCode(421)).to.eql(relayTCP)
+    })
+
+    it('ignores missing codes', () => {
+      const tcp = multiaddr('/ip4/0.0.0.0/tcp/8080')
+      expect(tcp.decapsulateCode(421)).to.eql(tcp)
+    })
+  })
+
   describe('.equals', () => {
     it('returns true for equal addresses', () => {
       const addr1 = multiaddr('/ip4/192.168.0.1')


### PR DESCRIPTION
This allows users to remove the last index of a given protocol code. It behaves like decapsulate, but checks protocol codes rather than string matching the whole multiaddr.

Unlike `decapsulate`, `decapsulateCode` will not throw when the code isn't present, it just returns the original address, because "I did what you asked" is better than "OMG I couldn't find it!!!".

## Why?
It's often the case in Libp2p that we want to encapsulate/decapsulate the PeerId in a Multiaddr. This makes it easier to avoid validation problems when using `mafmt`.

For example, let's say there is a peer at `/ip4/127.0.0.1/4001`, with an id of `QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC`. 
Encapsulated they yield, `/ip4/127.0.0.1/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC`.

If i do a validation check for tcp, it will fail, because `p2p` is not part of a valid tcp address. Today, we would do `addr.decapsulate('p2p')` to get the tcp address. 

The **problem** with this is:
1. `p2p` is the default now, but older versions use `ipfs`. So any protocol that has a name alias might fail depending on the version of multiaddr being used as the stringified address will be different. In a large ecosystem of modules like IPFS or Libp2p, it's common to have multiple versions of multiaddr as it's used so prevalently. 
1. Decapsulate currently matches **strings**. This is useful when you want to decapsulate more complex addresses. However, this will cause problems decapsulating protocols from complex addresses. 
    An address like `/ip4/0.0.0.0/tcp/8080/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit` would result in only `/p2p-circuit` being removed, instead of the actual `p2p` protocol.