### PR TITLE
Fix jsdoc for `fromNodeAddress`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -381,7 +381,7 @@ Multiaddr.prototype.nodeAddress = function nodeAddress () {
 /**
  * Creates a Multiaddr from a node-friendly address object
  *
- * @param {String} addr
+ * @param {Object} addr
  * @param {String} transport
  * @returns {Multiaddr} multiaddr
  * @throws {Error} Throws error if addr is not truthy

--- a/src/index.js
+++ b/src/index.js
@@ -381,7 +381,7 @@ Multiaddr.prototype.nodeAddress = function nodeAddress () {
 /**
  * Creates a Multiaddr from a node-friendly address object
  *
- * @param {Object} addr
+ * @param {{family: String, address: String, port: Number}} addr
  * @param {String} transport
  * @returns {Multiaddr} multiaddr
  * @throws {Error} Throws error if addr is not truthy


### PR DESCRIPTION
`addr` parameter for `fromNodeAddress`should not be `String` as it accepts an Object.
But maybe I should put `{family: String, address: String, port: Number}` instead?