### PR TITLE
feat: multiaddr support Peer ID represented as CID

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "homepage": "https://github.com/multiformats/js-multiaddr",
   "dependencies": {
     "bs58": "^4.0.1",
+    "cids": "~0.7.1",
     "class-is": "^1.1.0",
+    "hi-base32": "~0.5.0",
     "ip": "^1.1.5",
     "is-ip": "^3.1.0",
-    "varint": "^5.0.0",
-    "hi-base32": "~0.5.0"
+    "varint": "^5.0.0"
   },
   "devDependencies": {
     "aegir": "^20.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const codec = require('./codec')
 const protocols = require('./protocols-table')
 const varint = require('varint')
 const bs58 = require('bs58')
+const CID = require('cids')
 const withIs = require('class-is')
 
 /**
@@ -287,8 +288,8 @@ Multiaddr.prototype.getPeerId = function getPeerId () {
 
     // Get the last id
     b58str = tuples.pop()[1]
-
-    bs58.decode(b58str)
+    // Get multihash, unwrap from CID if needed
+    b58str = bs58.encode(new CID(b58str).multihash)
   } catch (e) {
     b58str = null
   }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -776,6 +776,11 @@ describe('helpers', () => {
         multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
+    it('parses extracts the peer Id from a multiaddr, p2p and CIDv1 Base32', () => {
+      expect(
+        multiaddr('/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4').getPeerId()
+      ).to.equal('QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi')
+    })
   })
 
   describe('.getPeerId should return null on missing peer id in multiaddr', () => {


### PR DESCRIPTION
### Motivation

This PR implements `Stage 1: Parse CIDs as peer ID` from https://github.com/libp2p/specs/issues/216. 

**TL;DR** This PR does not change the format returned by `getPeerId()`, all we do in `Stage 1` is adding support for Peer IDs represented with CIDs in text form.  

For a wider context see [libp2p/specs/RFC/0001-text-peerid-cid.md](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md), short story is that CID support will enable IPFS project to support `/ipns/{cid}` in Base32 (https://github.com/ipfs/ipfs/issues/337), enabling things like `http://{libp2p-key-as-cidv1b32}.ipns.dweb.link`

### Changes

This PR modifies `getPeerId()` to add support for Peer IDs as CIDs.
([libp2p RFC 0001](https://github.com/libp2p/specs/blob/master/RFC/0001-text-peerid-cid.md))

### Next

- We need this released, so we can switch IPNS implementation in js-ipfs to `createFromCID` 

cc https://github.com/ipfs/ipfs/issues/337, https://github.com/libp2p/specs/issues/216, https://github.com/libp2p/specs/pull/209