### PR TITLE
fix: ensure b58 can decode hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ coverage
 .lock-wscript
 
 build
+docs
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git

--- a/src/convert.js
+++ b/src/convert.js
@@ -126,7 +126,7 @@ function buf2str (buf) {
 
 function mh2buf (hash) {
   // the address is a varint prefixed multihash string representation
-  const mh = bs58.decode((new CID(hash)).toString('base58btc'))
+  const mh = new CID(hash).multihash
   const size = Buffer.from(varint.encode(mh.length))
   return Buffer.concat([size, mh])
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -4,6 +4,7 @@ const ip = require('ip')
 const isIp = require('is-ip')
 const protocols = require('./protocols-table')
 const bs58 = require('bs58')
+const CID = require('cids')
 const base32 = require('hi-base32')
 const varint = require('varint')
 
@@ -125,7 +126,7 @@ function buf2str (buf) {
 
 function mh2buf (hash) {
   // the address is a varint prefixed multihash string representation
-  const mh = Buffer.from(bs58.decode(hash))
+  const mh = bs58.decode((new CID(hash)).toString('base58btc'))
   const size = Buffer.from(varint.encode(mh.length))
   return Buffer.concat([size, mh])
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -761,7 +761,7 @@ describe('helpers', () => {
   })
 
   describe('.getPeerId should parse id from multiaddr', () => {
-    it('parses extracts the peer Id from a multiaddr, p2p', () => {
+    it('extracts the peer Id from a multiaddr, p2p', () => {
       expect(
         multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
@@ -771,17 +771,17 @@ describe('helpers', () => {
         multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
-    it('parses extracts the peer Id from a multiaddr, ipfs', () => {
+    it('extracts the peer Id from a multiaddr, ipfs', () => {
       expect(
         multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
-    it('parses extracts the peer Id from a multiaddr, p2p and CIDv1 Base32', () => {
+    it('extracts the peer Id from a multiaddr, p2p and CIDv1 Base32', () => {
       expect(
         multiaddr('/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4').getPeerId()
       ).to.equal('QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi')
     })
-    it('parses extracts the peer Id from a multiaddr, p2p and CIDv1 Base32, where Id contains non b58 chars', () => {
+    it('extracts the peer Id from a multiaddr, p2p and CIDv1 Base32, where Id contains non b58 chars', () => {
       expect(
         multiaddr('/p2p-circuit/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4').getPeerId()
       ).to.equal('QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -781,6 +781,11 @@ describe('helpers', () => {
         multiaddr('/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4').getPeerId()
       ).to.equal('QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi')
     })
+    it('parses extracts the peer Id from a multiaddr, p2p and CIDv1 Base32, where Id contains non b58 chars', () => {
+      expect(
+        multiaddr('/p2p-circuit/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4').getPeerId()
+      ).to.equal('QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')
+    })
   })
 
   describe('.getPeerId should return null on missing peer id in multiaddr', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -356,6 +356,13 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
+  it('p2p', () => {
+    const str = '/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('buffer')
+    expect(addr.toString()).to.equal('/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')
+  })
+
   it('ipfs', () => {
     const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)


### PR DESCRIPTION
While working on the libp2p refactor tests I found an issue with https://github.com/multiformats/js-multiaddr/pull/102, where if a base32 id contains non b58 characters (such as "l"), b58 would throw due to the unsupported character. This fixes that by getting the b58 string from the CID before decoding to a Buffer.