### PR TITLE
Fix typings and add type test

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,34 +1,44 @@
-/// <reference types="node" />
-
-declare interface NetOptions {
-  family: 'ipv4' | 'ipv6';
+declare type NetOptions = {
+  family: "ipv4" | "ipv6";
   host: string;
-  transport: string;
+  transport: "tcp" | "udp";
   port: number;
-}
+};
 
-declare interface Protocol {
+declare type Protocol = {
   code: number;
   size: number;
   name: string;
-  resolvable: boolean;
-  path: boolean;
-}
+  resolvable: boolean | undefined;
+  path: boolean | undefined;
+};
 
 declare interface Protocols {
-  table: [number, number, string, boolean?, boolean?][];
-  names: Record<string, Protocol>;
-  codes: Record<number, Protocol>;
-  object(code: number, size: number, name: string, resolvable?: any, path?: any): Protocol;
+  table: {
+    [index: number]: Protocol;
+  };
+  names: {
+    [index: string]: Protocol;
+  };
+  codes: {
+    [index: number]: Protocol;
+  };
+  object(
+    code: number,
+    size: number,
+    name: string,
+    resolvable?: any,
+    path?: any
+  ): Protocol;
 }
 
-declare interface NodeAddress {
-  family: 4 | 6;
+declare type NodeAddress = {
+  family: "IPv4" | "IPv6";
   address: string;
-  port: number;
-}
+  port: string;
+};
 
-declare type MultiaddrInput = string | Buffer | Multiaddr;
+declare type MultiaddrInput = string | Buffer | Multiaddr | null;
 
 declare class Multiaddr {
   /**
@@ -39,6 +49,8 @@ declare class Multiaddr {
    * to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
    */
   constructor(addr?: MultiaddrInput);
+
+  buffer: Buffer;
 
   /**
    * Returns Multiaddr as a String
@@ -142,20 +154,11 @@ declare class Multiaddr {
   isThinWaistAddress(addr?: Multiaddr): boolean;
 }
 
-declare interface MultiaddrClass {
-  /**
-   * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
-   * a Buffer, String or another Multiaddr instance
-   * public key.
-   * @param addr - If String or Buffer, needs to adhere
-   * to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
-   */
-  (addr?: MultiaddrInput): Multiaddr;
-
+declare namespace Multiaddr {
   /**
    * Creates a Multiaddr from a node-friendly address object
    */
-  fromNodeAddress(addr: NodeAddress, transport: string): Multiaddr;
+  function fromNodeAddress(addr: NodeAddress, transport: string): Multiaddr;
 
   /**
    * Object containing table, names and codes of all supported protocols.
@@ -164,22 +167,31 @@ declare interface MultiaddrClass {
    * [`.protoCodes()`](#multiaddrprotocodes) or
    * [`.protoNames()`](#multiaddrprotonames)
    */
-  protocols: Protocols;
+  const protocols: Protocols;
 
   /**
    * Returns if something is a Multiaddr
    */
-  isMultiaddr(addr: unknown): addr is Multiaddr;
+  function isMultiaddr(addr: unknown): addr is Multiaddr;
 
   /**
    * Returns if something is a Multiaddr that is a name
    */
-  isName(addr: Multiaddr): boolean;
+  function isName(addr: Multiaddr): boolean;
 
   /**
    * Returns an array of multiaddrs, by resolving the multiaddr that is a name
    */
-  resolve(addr: Multiaddr): Promise<Multiaddr[]>
+  function resolve(addr: Multiaddr): Promise<Multiaddr[]>;
 }
 
-export = MultiaddrClass;
+/**
+ * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
+ * a Buffer, String or another Multiaddr instance
+ * public key.
+ * @param addr - If String or Buffer, needs to adhere
+ * to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
+ */
+declare function Multiaddr(input?: MultiaddrInput): Multiaddr;
+
+export = Multiaddr;

--- a/src/index.js
+++ b/src/index.js
@@ -413,7 +413,17 @@ Multiaddr.prototype.nodeAddress = function nodeAddress () {
 Multiaddr.fromNodeAddress = function fromNodeAddress (addr, transport) {
   if (!addr) throw new Error('requires node address object')
   if (!transport) throw new Error('requires transport protocol')
-  const ip = (addr.family === 'IPv6') ? 'ip6' : 'ip4'
+  let ip
+  switch (addr.family) {
+    case 'IPv4':
+      ip = 'ip4'
+      break
+    case 'IPv6':
+      ip = 'ip6'
+      break
+    default:
+      throw Error(`Invalid addr family. Got '${addr.family}' instead of 'IPv4' or 'IPv6'`)
+  }
   return Multiaddr('/' + [ip, addr.address, transport, addr.port].join('/'))
 }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -53,16 +53,23 @@ describe('construction', () => {
 
   it('throws on truthy non string or buffer', () => {
     const errRegex = /addr must be a string/
+    // @ts-ignore
     expect(() => multiaddr({})).to.throw(errRegex)
+    // @ts-ignore
     expect(() => multiaddr([])).to.throw(errRegex)
+    // @ts-ignore
     expect(() => multiaddr(138)).to.throw(errRegex)
+    // @ts-ignore
     expect(() => multiaddr(true)).to.throw(errRegex)
   })
 
   it('throws on falsy non string or buffer', () => {
     const errRegex = /addr must be a string/
+    // @ts-ignore
     expect(() => multiaddr(NaN)).to.throw(errRegex)
+    // @ts-ignore
     expect(() => multiaddr(false)).to.throw(errRegex)
+    // @ts-ignore
     expect(() => multiaddr(0)).to.throw(errRegex)
   })
 })
@@ -694,6 +701,7 @@ describe('helpers', () => {
   describe('.fromNodeAddress', () => {
     it('throws on missing address object', () => {
       expect(
+        // @ts-ignore
         () => multiaddr.fromNodeAddress()
       ).to.throw(
         /requires node address/
@@ -702,6 +710,7 @@ describe('helpers', () => {
 
     it('throws on missing transport', () => {
       expect(
+        // @ts-ignore
         () => multiaddr.fromNodeAddress({ address: '0.0.0.0' })
       ).to.throw(
         /requires transport protocol/

--- a/test/types.spec.ts
+++ b/test/types.spec.ts
@@ -1,0 +1,22 @@
+import Multiaddr from "../src";
+
+const testStr: string = "/ip4/127.0.0.1";
+
+const maFromFunctionConstructor: Multiaddr = Multiaddr(testStr);
+
+const maFromClassConstructor: Multiaddr = new Multiaddr(testStr);
+
+const maFromMa: Multiaddr = Multiaddr(new Multiaddr(testStr));
+
+const maFromConstructorFunction: Multiaddr = Multiaddr.fromNodeAddress(
+  {
+    family: "IPv4",
+    address: "127.0.0.1",
+    port: "12345"
+  },
+  "udp"
+);
+
+function doSthWithMa(ma: Multiaddr): void {
+  ma.toOptions();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/index.d.ts", "test/**/*.spec.js"],
+  "include": ["src/index.d.ts", "test/**/*.spec.js", "test/**/*.spec.ts"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,38 +1,18 @@
-
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "target": "ES5",
-        "noImplicitAny": false,
-        "noImplicitThis": true,
-        "strictFunctionTypes": true,
-        "strictNullChecks": true,
-        "esModuleInterop": true,
-        "resolveJsonModule": true,
-        "allowJs": true,
-        "checkJs": true,
-        "baseUrl": ".",
-        "paths": {
-            "multiaddr": [
-                "./src",
-                "../src",
-            ]
-        },
-        "types": [
-            "node",
-            "mocha",
-            "chai"
-        ],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "files": [
-        "./src/index.d.ts",
-    ],
-    "include": [
-        "./test/**/*.spec.js"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "target": "ES5",
+    "noImplicitAny": false,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/index.d.ts", "test/**/*.spec.js"],
 }


### PR DESCRIPTION
This fixes some issues with typings and adds a test that checks whether we export the types correctly.

It also includes all installed `@types/...` types instead of having a manual configuration. See https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types for more information.