### PR TITLE
Use object shorthand for properties

### DIFF
--- a/src/codec.js
+++ b/src/codec.js
@@ -7,28 +7,28 @@ const varint = require('varint')
 
 // export codec
 module.exports = {
-  stringToStringTuples: stringToStringTuples,
-  stringTuplesToString: stringTuplesToString,
+  stringToStringTuples,
+  stringTuplesToString,
 
-  tuplesToStringTuples: tuplesToStringTuples,
-  stringTuplesToTuples: stringTuplesToTuples,
+  tuplesToStringTuples,
+  stringTuplesToTuples,
 
-  bufferToTuples: bufferToTuples,
-  tuplesToBuffer: tuplesToBuffer,
+  bufferToTuples,
+  tuplesToBuffer,
 
-  bufferToString: bufferToString,
-  stringToBuffer: stringToBuffer,
+  bufferToString,
+  stringToBuffer,
 
-  fromString: fromString,
-  fromBuffer: fromBuffer,
-  validateBuffer: validateBuffer,
-  isValidBuffer: isValidBuffer,
-  cleanPath: cleanPath,
+  fromString,
+  fromBuffer,
+  validateBuffer,
+  isValidBuffer,
+  cleanPath,
 
-  ParseError: ParseError,
-  protoFromTuple: protoFromTuple,
+  ParseError,
+  protoFromTuple,
 
-  sizeForAddr: sizeForAddr
+  sizeForAddr
 }
 
 // string -> [[str name, str addr]... ]

--- a/src/protocols-table.js
+++ b/src/protocols-table.js
@@ -72,9 +72,9 @@ Protocols.object = p
 
 function p (code, size, name, resolvable, path) {
   return {
-    code: code,
-    size: size,
-    name: name,
+    code,
+    size,
+    name,
     resolvable: Boolean(resolvable),
     path: Boolean(path)
   }


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: Since the code is transpired by aegir this should be compatible ✅ 
