### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = {
+  bundlesize: {
+    maxSize: '14kB'
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,18 +18,20 @@ js-multiaddr
 
 ## Table of Contents
 
-- [Background](#background)
-  - [What is multiaddr?](#what-is-multiaddr)
-- [Install](#install)
-  - [Setup](#setup)
-    - [Node.js](#nodejs)
-    - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
-    - [Browser: `<script>` Tag](#browser-script-tag)
-- [Usage](#usage)
-- [API](#api) - https://multiformats.github.io/js-multiaddr/
-- [Maintainers](#maintainers)
-- [Contribute](#contribute)
-- [License](#license)
+- [js-multiaddr](#js-multiaddr)
+  - [Lead Maintainer](#lead-maintainer)
+  - [Table of Contents](#table-of-contents)
+  - [Background](#background)
+    - [What is multiaddr?](#what-is-multiaddr)
+  - [Install](#install)
+    - [Setup](#setup)
+      - [Node.js](#nodejs)
+      - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
+      - [Browser: `<script>` Tag](#browser-script-tag)
+  - [Usage](#usage)
+  - [API](#api)
+  - [Contribute](#contribute)
+  - [License](#license)
 
 ## Background
 
@@ -79,10 +81,6 @@ the global namespace.
 <script src="https://unpkg.com/multiaddr/dist/index.js"></script>
 ```
 
-**NOTE**: You will need access to the Node.js `Buffer` API. If you are running
-in the browser, you can access it with `multiaddr.Buffer` or you can install
-[feross/buffer](https://github.com/feross/buffer).
-
 ## Usage
 
 ```js
@@ -93,8 +91,8 @@ $ node
 > const addr = multiaddr("/ip4/127.0.0.1/udp/1234")
 <Multiaddr /ip4/127.0.0.1/udp/1234>
 
-> addr.buffer
-<Buffer 04 7f 00 00 01 11 04 d2>
+> addr.bytes
+<Uint8Array 04 7f 00 00 01 11 04 d2>
 
 > addr.toString()
 '/ip4/127.0.0.1/udp/1234'

--- a/examples/try.js
+++ b/examples/try.js
@@ -5,9 +5,9 @@ var log = console.log
 
 var addr = multiaddr('/ip4/127.0.0.1/udp/1234')
 log(addr)
-log(addr.buffer)
+log(addr.bytes)
 log(addr.toString())
-log(multiaddr(addr.buffer))
+log(multiaddr(addr.bytes))
 
 log(addr.protoCodes())
 log(addr.protoNames())

--- a/intro.md
+++ b/intro.md
@@ -2,14 +2,14 @@ JavaScript implementation of [Multiaddr](https://github.com/multiformats/multiad
 
 ## What is multiaddr?
 
-Multiaddr is a standard way to represent addresses that: 
+Multiaddr is a standard way to represent addresses that:
 - Support any standard network protocols.
 - Self-describe (include protocols).
 - Have a binary packed format.
 - Have a nice string representation.
 - Encapsulate well.
 
-You can read more about what Multiaddr is in the language-independent Github repository: 
+You can read more about what Multiaddr is in the language-independent Github repository:
 https://github.com/multiformats/multiaddr
 
 Multiaddr is a part of a group of values called [Multiformats](https://github.com/multiformats/multiformats)
@@ -22,8 +22,8 @@ var Multiaddr = require('multiaddr')
 var home = new Multiaddr('/ip4/127.0.0.1/tcp/80')
 // <Multiaddr 047f000001060050 - /ip4/127.0.0.1/tcp/80>
 
-home.buffer
-// <Buffer 04 7f 00 00 01 06 00 50>
+home.bytes
+// <Uint8Array 04 7f 00 00 01 06 00 50>
 
 home.toString()
 // '/ip4/127.0.0.1/tcp/80'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "docs": "aegir docs",
-    "size": "bundlesize -f dist/index.min.js -s 14kB"
+    "size": "aegir build -b"
   },
   "files": [
     "src",
@@ -32,22 +32,19 @@
   "bugs": "https://github.com/multiformats/js-multiaddr/issues",
   "homepage": "https://github.com/multiformats/js-multiaddr",
   "dependencies": {
-    "buffer": "^5.5.0",
-    "cids": "~0.8.0",
+    "cids": "^1.0.0",
     "class-is": "^1.1.0",
     "is-ip": "^3.1.0",
-    "multibase": "^0.7.0",
+    "multibase": "^3.0.0",
+    "uint8arrays": "^1.1.0",
     "varint": "^5.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.8",
     "@types/dirty-chai": "^2.0.2",
-    "@types/mocha": "^7.0.1",
+    "@types/mocha": "^8.0.1",
     "@types/node": "^14.0.11",
-    "aegir": "^22.0.0",
-    "bundlesize": "~0.18.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
+    "aegir": "^25.0.0",
     "typescript": "^3.9.5"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/dirty-chai": "^2.0.2",
     "@types/mocha": "^8.0.1",
     "@types/node": "^14.0.11",
-    "aegir": "^25.0.0",
+    "aegir": "^22.0.0",
     "typescript": "^3.9.5"
   },
   "contributors": [

--- a/src/convert.js
+++ b/src/convert.js
@@ -1,20 +1,22 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const ip = require('./ip')
 const protocols = require('./protocols-table')
 const CID = require('cids')
 const multibase = require('multibase')
 const varint = require('varint')
+const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayConcat = require('uint8arrays/concat')
 
 module.exports = Convert
 
 // converts (serializes) addresses
 function Convert (proto, a) {
-  if (a instanceof Buffer) {
+  if (a instanceof Uint8Array) {
     return Convert.toString(proto, a)
   } else {
-    return Convert.toBuffer(proto, a)
+    return Convert.toBytes(proto, a)
   }
 }
 
@@ -23,13 +25,13 @@ Convert.toString = function convertToString (proto, buf) {
   switch (proto.code) {
     case 4: // ipv4
     case 41: // ipv6
-      return buf2ip(buf)
+      return bytes2ip(buf)
 
     case 6: // tcp
     case 273: // udp
     case 33: // dccp
     case 132: // sctp
-      return buf2port(buf)
+      return bytes2port(buf)
 
     case 53: // dns
     case 54: // dns4
@@ -37,32 +39,32 @@ Convert.toString = function convertToString (proto, buf) {
     case 56: // dnsaddr
     case 400: // unix
     case 777: // memory
-      return buf2str(buf)
+      return bytes2str(buf)
 
     case 421: // ipfs
-      return buf2mh(buf)
+      return bytes2mh(buf)
     case 444: // onion
-      return buf2onion(buf)
+      return bytes2onion(buf)
     case 445: // onion3
-      return buf2onion(buf)
+      return bytes2onion(buf)
     default:
-      return buf.toString('hex') // no clue. convert to hex
+      return uint8ArrayToString(buf, 'base16') // no clue. convert to hex
   }
 }
 
-Convert.toBuffer = function convertToBuffer (proto, str) {
+Convert.toBytes = function convertToBytes (proto, str) {
   proto = protocols(proto)
   switch (proto.code) {
     case 4: // ipv4
-      return ip2buf(str)
+      return ip2bytes(str)
     case 41: // ipv6
-      return ip2buf(str)
+      return ip2bytes(str)
 
     case 6: // tcp
     case 273: // udp
     case 33: // dccp
     case 132: // sctp
-      return port2buf(parseInt(str, 10))
+      return port2bytes(parseInt(str, 10))
 
     case 53: // dns
     case 54: // dns4
@@ -70,27 +72,27 @@ Convert.toBuffer = function convertToBuffer (proto, str) {
     case 56: // dnsaddr
     case 400: // unix
     case 777: // memory
-      return str2buf(str)
+      return str2bytes(str)
 
     case 421: // ipfs
-      return mh2buf(str)
+      return mh2bytes(str)
     case 444: // onion
-      return onion2buf(str)
+      return onion2bytes(str)
     case 445: // onion3
-      return onion32buf(str)
+      return onion32bytes(str)
     default:
-      return Buffer.from(str, 'hex') // no clue. convert from hex
+      return uint8ArrayFromString(str, 'base16') // no clue. convert from hex
   }
 }
 
-function ip2buf (ipString) {
+function ip2bytes (ipString) {
   if (!ip.isIP(ipString)) {
     throw new Error('invalid ip address')
   }
-  return ip.toBuffer(ipString)
+  return ip.toBytes(ipString)
 }
 
-function buf2ip (ipBuff) {
+function bytes2ip (ipBuff) {
   const ipString = ip.toString(ipBuff)
   if (!ipString || !ip.isIP(ipString)) {
     throw new Error('invalid ip address')
@@ -98,23 +100,26 @@ function buf2ip (ipBuff) {
   return ipString
 }
 
-function port2buf (port) {
-  const buf = Buffer.alloc(2)
-  buf.writeUInt16BE(port, 0)
-  return buf
+function port2bytes (port) {
+  const buf = new ArrayBuffer(2)
+  const view = new DataView(buf)
+  view.setUint16(0, port)
+
+  return new Uint8Array(buf)
 }
 
-function buf2port (buf) {
-  return buf.readUInt16BE(0)
+function bytes2port (buf) {
+  const view = new DataView(buf.buffer)
+  return view.getUint16(0)
 }
 
-function str2buf (str) {
-  const buf = Buffer.from(str)
-  const size = Buffer.from(varint.encode(buf.length))
-  return Buffer.concat([size, buf])
+function str2bytes (str) {
+  const buf = uint8ArrayFromString(str)
+  const size = Uint8Array.from(varint.encode(buf.length))
+  return uint8ArrayConcat([size, buf], size.length + buf.length)
 }
 
-function buf2str (buf) {
+function bytes2str (buf) {
   const size = varint.decode(buf)
   buf = buf.slice(varint.decode.bytes)
 
@@ -122,27 +127,28 @@ function buf2str (buf) {
     throw new Error('inconsistent lengths')
   }
 
-  return buf.toString()
+  return uint8ArrayToString(buf)
 }
 
-function mh2buf (hash) {
+function mh2bytes (hash) {
   // the address is a varint prefixed multihash string representation
   const mh = new CID(hash).multihash
-  const size = Buffer.from(varint.encode(mh.length))
-  return Buffer.concat([size, mh])
+  const size = Uint8Array.from(varint.encode(mh.length))
+  return uint8ArrayConcat([size, mh], size.length + mh.length)
 }
 
-function buf2mh (buf) {
+function bytes2mh (buf) {
   const size = varint.decode(buf)
   const address = buf.slice(varint.decode.bytes)
 
   if (address.length !== size) {
     throw new Error('inconsistent lengths')
   }
-  return multibase.encode('base58btc', address).toString().slice(1)
+
+  return uint8ArrayToString(address, 'base58btc')
 }
 
-function onion2buf (str) {
+function onion2bytes (str) {
   const addr = str.split(':')
   if (addr.length !== 2) {
     throw new Error('failed to parse onion addr: ' + addr + ' does not contain a port number')
@@ -159,11 +165,11 @@ function onion2buf (str) {
   if (port < 1 || port > 65536) {
     throw new Error('Port number is not in range(1, 65536)')
   }
-  const portBuf = port2buf(port)
-  return Buffer.concat([buf, portBuf])
+  const portBuf = port2bytes(port)
+  return uint8ArrayConcat([buf, portBuf], buf.length + portBuf.length)
 }
 
-function onion32buf (str) {
+function onion32bytes (str) {
   const addr = str.split(':')
   if (addr.length !== 2) {
     throw new Error('failed to parse onion addr: ' + addr + ' does not contain a port number')
@@ -179,14 +185,14 @@ function onion32buf (str) {
   if (port < 1 || port > 65536) {
     throw new Error('Port number is not in range(1, 65536)')
   }
-  const portBuf = port2buf(port)
-  return Buffer.concat([buf, portBuf])
+  const portBuf = port2bytes(port)
+  return uint8ArrayConcat([buf, portBuf], buf.length + portBuf.length)
 }
 
-function buf2onion (buf) {
+function bytes2onion (buf) {
   const addrBytes = buf.slice(0, buf.length - 2)
   const portBytes = buf.slice(buf.length - 2)
-  const addr = multibase.encode('base32', addrBytes).toString().slice(1)
-  const port = buf2port(portBytes)
+  const addr = uint8ArrayToString(addrBytes, 'base32')
+  const port = bytes2port(portBytes)
   return addr + ':' + port
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,19 +38,19 @@ declare type NodeAddress = {
   port: string;
 };
 
-declare type MultiaddrInput = string | Buffer | Multiaddr | null;
+declare type MultiaddrInput = string | Uint8Array | Multiaddr | null;
 
 declare class Multiaddr {
   /**
    * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
-   * a Buffer, String or another Multiaddr instance
+   * a Uint8Array, String or another Multiaddr instance
    * public key.
-   * @param addr - If String or Buffer, needs to adhere
+   * @param addr - If String or Uint8Array, needs to adhere
    * to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
    */
   constructor(addr?: MultiaddrInput);
 
-  buffer: Buffer;
+  bytes: Uint8Array;
 
   /**
    * Returns Multiaddr as a String
@@ -95,7 +95,7 @@ declare class Multiaddr {
   /**
    * Returns a tuple of parts
    */
-  tuples(): [number, Buffer][];
+  tuples(): [number, Uint8Array][];
 
   /**
    * Returns a tuple of string/number parts
@@ -187,9 +187,9 @@ declare namespace Multiaddr {
 
 /**
  * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
- * a Buffer, String or another Multiaddr instance
+ * a Uint8Array, String or another Multiaddr instance
  * public key.
- * @param addr - If String or Buffer, needs to adhere
+ * @param addr - If String or Uint8Array, needs to adhere
  * to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
  */
 declare function Multiaddr(input?: MultiaddrInput): Multiaddr;

--- a/test/codec.spec.js
+++ b/test/codec.spec.js
@@ -3,10 +3,8 @@
 
 const codec = require('../src/codec')
 const varint = require('varint')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('codec', () => {
   describe('.stringToStringTuples', () => {
@@ -24,7 +22,7 @@ describe('codec', () => {
       expect(
         codec.stringTuplesToTuples([['ip4', '0.0.0.0'], 'utp'])
       ).to.eql(
-        [[4, Buffer.from([0, 0, 0, 0])], [302]]
+        [[4, Uint8Array.from([0, 0, 0, 0])], [302]]
       )
     })
   })
@@ -39,34 +37,34 @@ describe('codec', () => {
     })
   })
 
-  describe('.bufferToTuples', () => {
+  describe('.bytesToTuples', () => {
     it('throws on invalid address', () => {
       expect(
-        () => codec.bufferToTuples(codec.tuplesToBuffer([[4, Buffer.from('192')]]))
+        () => codec.bytesToTuples(codec.tuplesToBytes([[4, uint8ArrayFromString('192')]]))
       ).to.throw(
-        /Invalid address buffer/
+        /Invalid address/
       )
     })
   })
 
-  describe('.fromBuffer', () => {
+  describe('.fromBytes', () => {
     it('throws on invalid buffer', () => {
       expect(
-        () => codec.fromBuffer(Buffer.from('hello/world'))
+        () => codec.fromBytes(uint8ArrayFromString('hello/world'))
       ).to.throw()
     })
   })
 
-  describe('.isValidBuffer', () => {
+  describe('.isValidBytes', () => {
     it('returns true for valid buffers', () => {
       expect(
-        codec.isValidBuffer(Buffer.from(varint.encode(302)))
+        codec.isValidBytes(Uint8Array.from(varint.encode(302)))
       ).to.equal(true)
     })
 
     it('returns false for invalid buffers', () => {
       expect(
-        codec.isValidBuffer(Buffer.from(varint.encode(1234)))
+        codec.isValidBytes(Uint8Array.from(varint.encode(1234)))
       ).to.equal(false)
     })
   })

--- a/test/convert.spec.js
+++ b/test/convert.spec.js
@@ -2,15 +2,13 @@
 'use strict'
 
 const convert = require('../src/convert')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('convert', () => {
   it('handles ip4 buffers', () => {
     expect(
-      convert('ip4', Buffer.from('c0a80001', 'hex'))
+      convert('ip4', uint8ArrayFromString('c0a80001', 'base16'))
     ).to.eql(
       '192.168.0.1'
     )
@@ -18,7 +16,7 @@ describe('convert', () => {
 
   it('handles ip6 buffers', () => {
     expect(
-      convert('ip6', Buffer.from('abcd0000000100020003000400050006', 'hex'))
+      convert('ip6', uint8ArrayFromString('abcd0000000100020003000400050006', 'base16'))
     ).to.eql(
       'abcd:0:1:2:3:4:5:6'
     )
@@ -28,7 +26,7 @@ describe('convert', () => {
     expect(
       convert('ip6', 'ABCD::1:2:3:4:5:6')
     ).to.eql(
-      Buffer.from('ABCD0000000100020003000400050006', 'hex')
+      uint8ArrayFromString('ABCD0000000100020003000400050006', 'base16upper')
     )
   })
 
@@ -36,7 +34,7 @@ describe('convert', () => {
     expect(
       convert('ip4', '192.168.0.1')
     ).to.eql(
-      Buffer.from('c0a80001', 'hex')
+      uint8ArrayFromString('c0a80001', 'base16')
     )
   })
 
@@ -56,19 +54,19 @@ describe('convert', () => {
     )
   })
 
-  describe('.toBuffer', () => {
+  describe('.toBytes', () => {
     it('defaults to hex conversion', () => {
       expect(
-        convert.toBuffer('ws', 'c0a80001')
+        convert.toBytes('ws', 'c0a80001')
       ).to.eql(
-        Buffer.from([192, 168, 0, 1])
+        Uint8Array.from([192, 168, 0, 1])
       )
     })
   })
 
   describe('.toString', () => {
     it('throws on inconsistent ipfs links', () => {
-      const valid = Buffer.from('03221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a68911c0b', 'hex')
+      const valid = uint8ArrayFromString('03221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a68911c0b', 'base16')
       expect(
         () => convert.toString('ipfs', valid.slice(0, valid.length - 8))
       ).to.throw(
@@ -78,7 +76,7 @@ describe('convert', () => {
 
     it('defaults to hex conversion', () => {
       expect(
-        convert.toString('ws', Buffer.from([192, 168, 0, 1]))
+        convert.toString('ws', Uint8Array.from([192, 168, 0, 1]))
       ).to.eql(
         'c0a80001'
       )

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,10 +3,8 @@
 'use strict'
 
 const multiaddr = require('../src')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('construction', () => {
   let udpAddr
@@ -22,23 +20,23 @@ describe('construction', () => {
   })
 
   it('reconstruct with buffer', () => {
-    expect(multiaddr(udpAddr.buffer).buffer === udpAddr.buffer).to.equal(false)
-    expect(multiaddr(udpAddr.buffer).buffer).to.deep.equal(udpAddr.buffer)
+    expect(multiaddr(udpAddr.bytes).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr.bytes).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with string', () => {
-    expect(multiaddr(udpAddr.toString()).buffer === udpAddr.buffer).to.equal(false)
-    expect(multiaddr(udpAddr.toString()).buffer).to.deep.equal(udpAddr.buffer)
+    expect(multiaddr(udpAddr.toString()).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr.toString()).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with object', () => {
-    expect(multiaddr(udpAddr).buffer === udpAddr.buffer).to.equal(false)
-    expect(multiaddr(udpAddr).buffer).to.deep.equal(udpAddr.buffer)
+    expect(multiaddr(udpAddr).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with JSON', () => {
-    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).buffer === udpAddr.buffer).to.equal(false)
-    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).buffer).to.deep.equal(udpAddr.buffer)
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('empty construct still works', () => {
@@ -88,18 +86,18 @@ describe('requiring varint', () => {
   })
 
   it('reconstruct with buffer', () => {
-    expect(multiaddr(uTPAddr.buffer).buffer === uTPAddr.buffer).to.equal(false)
-    expect(multiaddr(uTPAddr.buffer).buffer).to.deep.equal(uTPAddr.buffer)
+    expect(multiaddr(uTPAddr.bytes).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr.bytes).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('reconstruct with string', () => {
-    expect(multiaddr(uTPAddr.toString()).buffer === uTPAddr.buffer).to.equal(false)
-    expect(multiaddr(uTPAddr.toString()).buffer).to.deep.equal(uTPAddr.buffer)
+    expect(multiaddr(uTPAddr.toString()).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr.toString()).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('reconstruct with object', () => {
-    expect(multiaddr(uTPAddr).buffer === uTPAddr.buffer).to.equal(false)
-    expect(multiaddr(uTPAddr).buffer).to.deep.equal(uTPAddr.buffer)
+    expect(multiaddr(uTPAddr).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('empty construct still works', () => {
@@ -110,21 +108,21 @@ describe('requiring varint', () => {
 describe('manipulation', () => {
   it('basic', () => {
     const udpAddrStr = '/ip4/127.0.0.1/udp/1234'
-    const udpAddrBuf = Buffer.from('047f000001910204d2', 'hex')
+    const udpAddrBuf = uint8ArrayFromString('047f000001910204d2', 'base16')
     const udpAddr = multiaddr(udpAddrStr)
 
     expect(udpAddr.toString()).to.equal(udpAddrStr)
-    expect(udpAddr.buffer).to.deep.equal(udpAddrBuf)
+    expect(udpAddr.bytes).to.deep.equal(udpAddrBuf)
 
     expect(udpAddr.protoCodes()).to.deep.equal([4, 273])
     expect(udpAddr.protoNames()).to.deep.equal(['ip4', 'udp'])
     expect(udpAddr.protos()).to.deep.equal([multiaddr.protocols.codes[4], multiaddr.protocols.codes[273]])
     expect(udpAddr.protos()[0] === multiaddr.protocols.codes[4]).to.equal(false)
 
-    const udpAddrBuf2 = udpAddr.encapsulate('/udp/5678')
-    expect(udpAddrBuf2.toString()).to.equal('/ip4/127.0.0.1/udp/1234/udp/5678')
-    expect(udpAddrBuf2.decapsulate('/udp').toString()).to.equal('/ip4/127.0.0.1/udp/1234')
-    expect(udpAddrBuf2.decapsulate('/ip4').toString()).to.equal('/')
+    const udpAddrbytes2 = udpAddr.encapsulate('/udp/5678')
+    expect(udpAddrbytes2.toString()).to.equal('/ip4/127.0.0.1/udp/1234/udp/5678')
+    expect(udpAddrbytes2.decapsulate('/udp').toString()).to.equal('/ip4/127.0.0.1/udp/1234')
+    expect(udpAddrbytes2.decapsulate('/ip4').toString()).to.equal('/')
     expect(function () { udpAddr.decapsulate('/').toString() }).to.throw()
     expect(multiaddr('/').encapsulate(udpAddr).toString()).to.equal(udpAddr.toString())
     expect(multiaddr('/').decapsulate('/').toString()).to.equal('/')
@@ -184,63 +182,63 @@ describe('variants', () => {
   it('ip4', () => {
     const str = '/ip4/127.0.0.1'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp', () => {
     const str = '/ip4/127.0.0.1/tcp/5000'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/5000'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + udp', () => {
     const str = '/ip4/127.0.0.1/udp/5000'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/5000'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + p2p', () => {
     const str = '/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + ipfs', () => {
     const str = '/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
@@ -253,14 +251,14 @@ describe('variants', () => {
   it('ip4 + udp + utp', () => {
     const str = '/ip4/127.0.0.1/udp/5000/utp'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp + utp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/5000/utp'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.protoNames())
     expect(addr.toString()).to.equal(str)
   })
@@ -268,119 +266,119 @@ describe('variants', () => {
   it('ip4 + tcp + http', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/http'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + unix', () => {
     const str = '/ip4/127.0.0.1/tcp/80/unix/a/b/c/d/e/f'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + http', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/http'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + unix', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/unix/a/b/c/d/e/f'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + https', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/https'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + https', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/https'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + websockets', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/ws'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets + ipfs', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + tcp + websockets + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp + quic + ipfs', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + udp + quic + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('unix', () => {
     const str = '/unix/a/b/c/d/e'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p', () => {
     const str = '/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal('/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')
   })
 
   it('ipfs', () => {
     const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('onion', () => {
     const str = '/onion/timaq4ygg2iegci7:1234'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
@@ -402,7 +400,7 @@ describe('variants', () => {
   it('onion3', () => {
     const str = '/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
@@ -424,56 +422,56 @@ describe('variants', () => {
   it('p2p-circuit', () => {
     const str = '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-circuit p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-circuit ipfs', () => {
     const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('p2p-webrtc-star', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-webrtc-star ipfs', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('p2p-webrtc-direct', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-websocket-star', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('memory + p2p', () => {
     const str = '/memory/test/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
     const addr = multiaddr(str)
-    expect(addr).to.have.property('buffer')
+    expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 })
@@ -611,7 +609,7 @@ describe('helpers', () => {
     it('returns the tuples', () => {
       expect(multiaddr('/ip4/0.0.0.0/utp').tuples())
         .to.eql([
-          [4, Buffer.from([0, 0, 0, 0])],
+          [4, Uint8Array.from([0, 0, 0, 0])],
           [302]
         ])
     })
@@ -863,7 +861,7 @@ describe('helpers', () => {
       expect(multiaddr.isMultiaddr('/')).to.be.eql(false)
       expect(multiaddr.isMultiaddr(123)).to.be.eql(false)
 
-      expect(multiaddr.isMultiaddr(Buffer.from('/hello'))).to.be.eql(false)
+      expect(multiaddr.isMultiaddr(uint8ArrayFromString('/hello'))).to.be.eql(false)
     })
   })
 

--- a/test/protocols.spec.js
+++ b/test/protocols.spec.js
@@ -2,10 +2,7 @@
 'use strict'
 
 const protocols = require('../src/protocols-table')
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 
 describe('protocols', () => {
   describe('throws on non existent protocol', () => {


### PR DESCRIPTION
All uses of node Buffers have been replaced with Uint8Arrays.

Also redundant modules have been removed from package.json

BREAKING CHANGES:

- Where node Buffers were returned, now Uint8Arrays are
- The `.buffer` property has been renamed `.bytes` similar to cid@1.0.0