### PR TITLE
Support buffer with any byteOffset values instead of 0

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -110,7 +110,7 @@ function port2bytes (port) {
 
 function bytes2port (buf) {
   const view = new DataView(buf.buffer)
-  return view.getUint16(0)
+  return view.getUint16(buf.byteOffset)
 }
 
 function str2bytes (str) {


### PR DESCRIPTION
Got an issue when save port to a Buffer and use `convert.toString()` to get it back, it turns out multiaddr only expect a Buffer with 0 byte offset, this should support all types of Buffer.