### PR TITLE
feat: resolve multiaddrs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ stages:
   - cov
 
 node_js:
-  - '10'
+  - 'lts/*'
+  - 'stable'
 
 os:
   - linux

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ https://multiformats.github.io/js-multiaddr/
 
 ## Resolvers
 
-`multiaddr` allows multiaddrs to be resolved when appropriate resolvers are provided. This module already has resolvers available, but you can also create your own. To provide multiaddr resolvers you can do:
+`multiaddr` allows multiaddrs to be resolved when appropriate resolvers are provided. This module already has resolvers available, but you can also create your own.  Resolvers should always be set in the same module that is calling `multiaddr.resolve()` to avoid conflicts if multiple versions of `multiaddr` are in your dependency tree. 
+To provide multiaddr resolvers you can do:
 
 ```js
 const multiaddr = require('multiaddr')

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ js-multiaddr
       - [Browser: `<script>` Tag](#browser-script-tag)
   - [Usage](#usage)
   - [API](#api)
+  - [Resolvers](#resolvers)
   - [Contribute](#contribute)
   - [License](#license)
 
@@ -116,6 +117,25 @@ $ node
 ## API
 
 https://multiformats.github.io/js-multiaddr/
+
+## Resolvers
+
+`multiaddr` allows multiaddrs to be resolved when appropriate resolvers are provided. This module already has resolvers available, but you can also create your own. To provide multiaddr resolvers you can do:
+
+```js
+const multiaddr = require('multiaddr')
+const resolvers = require('multiaddr/src/resolvers')
+
+multiaddr.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+```
+
+The available resolvers are:
+
+|     Name    | type | Description |
+|-------------|------|-------------|
+| `dnsaddrResolver` | `dnsaddr` | dnsaddr resolution with TXT Records |
+
+A resolver receives a `Multiaddr` as a parameter and returns a `Promise<Array<string>>`.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "docs": "aegir docs",
     "size": "aegir build -b"
   },
+  "browser": {
+    "./src/resolvers/dns.js": "./src/resolvers/dns.browser.js"
+  },
   "files": [
     "src",
     "dist"
@@ -34,6 +37,8 @@
   "dependencies": {
     "cids": "^1.0.0",
     "class-is": "^1.1.0",
+    "dns-over-http-resolver": "vasco-santos/dns-over-http-resolver#feat/initial-implementation",
+    "err-code": "^2.0.3",
     "is-ip": "^3.1.0",
     "multibase": "^3.0.0",
     "uint8arrays": "^1.1.0",
@@ -45,6 +50,7 @@
     "@types/mocha": "^8.0.1",
     "@types/node": "^14.0.11",
     "aegir": "^26.0.0",
+    "sinon": "^9.2.0",
     "typescript": "^3.9.5"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "cids": "^1.0.0",
     "class-is": "^1.1.0",
-    "dns-over-http-resolver": "vasco-santos/dns-over-http-resolver#feat/initial-implementation",
+    "dns-over-http-resolver": "^1.0.0",
     "err-code": "^2.0.3",
     "is-ip": "^3.1.0",
     "multibase": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
     "docs": "aegir docs",
     "size": "aegir build -b"
   },
-  "browser": {
-    "./src/resolvers/dns.js": "./src/resolvers/dns.browser.js"
-  },
   "files": [
     "src",
     "dist"

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,6 +52,8 @@ declare class Multiaddr {
 
   bytes: Uint8Array;
 
+  resolvers: Map<string, (addr: Multiaddr) => Promise<Array<string>>>
+
   /**
    * Returns Multiaddr as a String
    */
@@ -152,6 +154,11 @@ declare class Multiaddr {
    * `{IPv4, IPv6}/{TCP, UDP}`
    */
   isThinWaistAddress(addr?: Multiaddr): boolean;
+
+  /**
+   * Resolve multiaddr if containing resolvable hostname.
+   */
+  resolve(options?: object): Promise<Array<Multiaddr>>
 }
 
 declare namespace Multiaddr {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -52,8 +52,6 @@ declare class Multiaddr {
 
   bytes: Uint8Array;
 
-  resolvers: Map<string, (addr: Multiaddr) => Promise<Array<string>>>
-
   /**
    * Returns Multiaddr as a String
    */
@@ -162,6 +160,8 @@ declare class Multiaddr {
 }
 
 declare namespace Multiaddr {
+  const resolvers: Map < string, (addr: Multiaddr) => Promise < Array < string >>>
+
   /**
    * Creates a Multiaddr from a node-friendly address object
    */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -158,7 +158,7 @@ declare class Multiaddr {
   /**
    * Resolve multiaddr if containing resolvable hostname.
    */
-  resolve(options?: object): Promise<Array<Multiaddr>>
+  resolve(): Promise<Array<Multiaddr>>
 }
 
 declare namespace Multiaddr {

--- a/src/index.js
+++ b/src/index.js
@@ -373,7 +373,6 @@ Multiaddr.prototype.equals = function equals (addr) {
  * Resolve multiaddr if containing resolvable hostname.
  *
  * @param {object} options
- * @param {bool} [options.recursive = true] recursive resolve until no resolvable multiaddr reached
  * @returns {Promise<Array<Multiaddr>>}
  * @example
  * const mh1 = Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
@@ -385,12 +384,12 @@ Multiaddr.prototype.equals = function equals (addr) {
  * //   <Multiaddr 04934b535391020fa1cc03a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>
  * // ]
  */
-Multiaddr.prototype.resolve = async function resolve ({ recursive = true } = {}) {
+Multiaddr.prototype.resolve = async function resolve () {
   const resolvableProto = this.protos().find((p) => p.resolvable)
 
   // Multiaddr is not resolvable?
   if (!resolvableProto) {
-    return this
+    return [this]
   }
 
   const resolver = this.resolvers.get(resolvableProto.name)
@@ -399,19 +398,7 @@ Multiaddr.prototype.resolve = async function resolve ({ recursive = true } = {})
   }
 
   const addresses = await resolver(this)
-  const newMultiaddrs = addresses.map(a => Multiaddr(a))
-
-  if (!recursive) {
-    return newMultiaddrs
-  }
-
-  // Inject Resolvers and resolve
-  const recursiveMultiaddrs = await Promise.all(newMultiaddrs.map((nm) => {
-    nm.resolvers = this.resolvers
-    return nm.resolve()
-  }))
-
-  return recursiveMultiaddrs.flat()
+  return addresses.map(a => Multiaddr(a))
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,8 @@ const inspect = Symbol.for('nodejs.util.inspect.custom')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayEquals = require('uint8arrays/equals')
 
+const resolvers = new Map()
+
 /**
  * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
  * a Uint8Array, String or another Multiaddr instance
@@ -46,8 +48,6 @@ const Multiaddr = withIs.proto(function (addr) {
   } else {
     throw new Error('addr must be a string, Buffer, or another Multiaddr')
   }
-
-  this.resolvers = new Map()
 }, { className: 'Multiaddr', symbolName: '@multiformats/js-multiaddr/multiaddr' })
 
 /**
@@ -375,8 +375,8 @@ Multiaddr.prototype.equals = function equals (addr) {
  * @param {object} options
  * @returns {Promise<Array<Multiaddr>>}
  * @example
+ * Multiaddr.resolvers.set('dnsaddr', resolverFunction)
  * const mh1 = Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
- * mh1.resolvers.set('dnsaddr', resolverFunction)
  * const resolvedMultiaddrs = await mh1.resolve()
  * // [
  * //   <Multiaddr 04934b5353060fa1a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>,
@@ -392,7 +392,7 @@ Multiaddr.prototype.resolve = async function resolve () {
     return [this]
   }
 
-  const resolver = this.resolvers.get(resolvableProto.name)
+  const resolver = resolvers.get(resolvableProto.name)
   if (!resolver) {
     throw errCode(new Error(`no available resolver for ${resolvableProto.name}`), 'ERR_NO_AVAILABLE_RESOLVER')
   }
@@ -551,4 +551,5 @@ Multiaddr.resolve = function resolve (addr) {
   return Promise.reject(new Error('not implemented yet'))
 }
 
+Multiaddr.resolvers = resolvers
 exports = module.exports = Multiaddr

--- a/src/resolvers/dns.browser.js
+++ b/src/resolvers/dns.browser.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('dns-over-http-resolver')

--- a/src/resolvers/dns.browser.js
+++ b/src/resolvers/dns.browser.js
@@ -1,3 +1,0 @@
-'use strict'
-
-module.exports = require('dns-over-http-resolver')

--- a/src/resolvers/dns.js
+++ b/src/resolvers/dns.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('dns').promises

--- a/src/resolvers/dns.js
+++ b/src/resolvers/dns.js
@@ -1,3 +1,11 @@
 'use strict'
 
-module.exports = require('dns').promises
+let dns
+
+try {
+  dns = require('dns').promises
+} catch (err) {
+  dns = require('dns-over-http-resolver')
+}
+
+module.exports = dns

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const Multiaddr = require('..') // eslint-disable-line  no-unused-vars
+
+/**
+ * Resolver for dnsaddr addresses.
+ *
+ * @param {Multiaddr} addr
+ * @returns {Promise<Array<string>>}
+ */
+async function dnsaddrResolver (addr) {
+  const { Resolver } = require('./dns')
+  const resolver = new Resolver()
+
+  const peerId = addr.getPeerId()
+  const hostname = addr.toString().split('dnsaddr')[1].split('/')[1]
+
+  const records = await resolver.resolveTxt(`_dnsaddr.${hostname}`)
+  // @ts-ignore
+  let addresses = records.flat().map((a) => a.split('=')[1])
+
+  if (peerId) {
+    addresses = addresses.filter((entry) => entry.includes(peerId))
+  }
+
+  return addresses
+}
+
+module.exports = {
+  dnsaddrResolver
+}

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const Multiaddr = require('..') // eslint-disable-line  no-unused-vars
+const protocols = require('../protocols-table')
+
+const { code: dnsaddrCode } = protocols('dnsaddr')
 
 /**
  * Resolver for dnsaddr addresses.
@@ -13,7 +16,7 @@ async function dnsaddrResolver (addr) {
   const resolver = new Resolver()
 
   const peerId = addr.getPeerId()
-  const hostname = addr.toString().split('dnsaddr')[1].split('/')[1]
+  const [, hostname] = addr.stringTuples().find(([proto]) => proto === dnsaddrCode) || []
 
   const records = await resolver.resolveTxt(`_dnsaddr.${hostname}`)
   // @ts-ignore

--- a/test/resolvers.spec.js
+++ b/test/resolvers.spec.js
@@ -51,9 +51,6 @@ describe('multiaddr resolve', () => {
       const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
 
-      // Set resolvers
-      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
-
       // Resolve
       const resolvedMas = await ma.resolve()
 
@@ -72,9 +69,6 @@ describe('multiaddr resolve', () => {
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
       stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
 
-      // Set resolvers
-      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
-
       // Resolve
       const resolvedMas = await ma.resolve()
 
@@ -88,9 +82,6 @@ describe('multiaddr resolve', () => {
       const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
       stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
-
-      // Set resolvers
-      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
 
       // Resolve
       const resolvedInitialMas = await ma.resolve()

--- a/test/resolvers.spec.js
+++ b/test/resolvers.spec.js
@@ -27,17 +27,22 @@ const dnsaddrStub2 = [
 ]
 
 describe('multiaddr resolve', () => {
+  it('should throw if no resolver is available', async () => {
+    const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+    // Resolve
+    await expect(ma.resolve()).to.eventually.be.rejected()
+      .and.to.have.property('code', 'ERR_NO_AVAILABLE_RESOLVER')
+  })
+
   describe('dnsaddr', () => {
-    afterEach(() => {
-      sinon.restore()
+    before(() => {
+      // Set resolvers
+      multiaddr.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
     })
 
-    it('should throw if no resolver is available', async () => {
-      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
-
-      // Resolve
-      await expect(ma.resolve()).to.eventually.be.rejected()
-        .and.to.have.property('code', 'ERR_NO_AVAILABLE_RESOLVER')
+    afterEach(() => {
+      sinon.restore()
     })
 
     it('can resolve dnsaddr without no peerId', async () => {
@@ -47,7 +52,7 @@ describe('multiaddr resolve', () => {
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
 
       // Set resolvers
-      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
 
       // Resolve
       const resolvedMas = await ma.resolve()
@@ -68,7 +73,7 @@ describe('multiaddr resolve', () => {
       stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
 
       // Set resolvers
-      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
 
       // Resolve
       const resolvedMas = await ma.resolve()
@@ -85,12 +90,12 @@ describe('multiaddr resolve', () => {
       stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
 
       // Set resolvers
-      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+      // ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
 
       // Resolve
       const resolvedInitialMas = await ma.resolve()
       const resolvedSecondMas = await Promise.all(resolvedInitialMas.map(nm => {
-        nm.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+        //  nm.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
         return nm.resolve()
       }))
       // @ts-ignore

--- a/test/resolvers.spec.js
+++ b/test/resolvers.spec.js
@@ -1,0 +1,101 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('aegir/utils/chai')
+const sinon = require('sinon')
+
+const multiaddr = require('../src')
+const resolvers = require('../src/resolvers')
+const { Resolver } = require('../src/resolvers/dns')
+
+const dnsaddrStub1 = [
+  ['dnsaddr=/dnsaddr/ams-1.bootstrap.libp2p.io/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd'],
+  ['dnsaddr=/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/dnsaddr/lon-1.bootstrap.libp2p.io/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3'],
+  ['dnsaddr=/dnsaddr/nrt-1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'],
+  ['dnsaddr=/dnsaddr/nyc-1.bootstrap.libp2p.io/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm'],
+  ['dnsaddr=/dnsaddr/sfo-2.bootstrap.libp2p.io/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z']
+]
+
+const dnsaddrStub2 = [
+  ['dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
+  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb']
+]
+
+describe('multiaddr resolve', () => {
+  describe('dnsaddr', () => {
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should throw if no resolver is available', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+      // Resolve
+      await expect(ma.resolve()).to.eventually.be.rejected()
+        .and.to.have.property('code', 'ERR_NO_AVAILABLE_RESOLVER')
+    })
+
+    it('can resolve dnsaddr without no peerId', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
+      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
+
+      // Set resolvers
+      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+
+      // Resolve
+      const resolvedMas = await ma.resolve({ recursive: false })
+
+      expect(resolvedMas).to.have.length(dnsaddrStub1.length)
+      resolvedMas.forEach((ma, index) => {
+        const stubAddr = dnsaddrStub1[index][0].split('=')[1]
+
+        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
+      })
+    })
+
+    it('can resolve dnsaddr with peerId recursively', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+
+      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
+      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
+      stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
+
+      // Set resolvers
+      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+
+      // Resolve
+      const resolvedMas = await ma.resolve()
+
+      expect(resolvedMas).to.have.length(dnsaddrStub2.length)
+      resolvedMas.forEach((ma, index) => {
+        const stubAddr = dnsaddrStub2[index][0].split('=')[1]
+
+        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
+      })
+    })
+
+    it('can resolve dnsaddr with peerId not recursively', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+
+      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
+      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
+      stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
+
+      // Set resolvers
+      ma.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+
+      // Resolve
+      const resolvedMas = await ma.resolve({ recursive: false })
+
+      expect(resolvedMas).to.have.length(1)
+      expect(resolvedMas[0].equals(multiaddr('/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'))).to.eql(true)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the resolve API method to multiaddr, as well as a custom resolver for `dnsaddr` that `multiaddr` users can rely on. Further custom resolvers including `dns4` and `dns6` should be added to this repo.

Needs:

- [x] https://github.com/vasco-santos/dns-over-http-resolver/pull/1

Closes #94 