### PR TITLE
chore: release script workaround typescript fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "test:browser": "aegir test -t browser",
     "test:types": "npx tsc",
     "build": "aegir build",
-    "release": "aegir release",
-    "release-minor": "aegir release --type minor",
-    "release-major": "aegir release --type major",
+    "prerelease": "npm run test:node && npm run test:browser",
+    "release": "aegir release --no-test",
+    "release-minor": "aegir release --type minor --no-test",
+    "release-major": "aegir release --type major --no-test",
     "docs": "aegir docs",
     "size": "aegir build -b"
   },


### PR DESCRIPTION
With the aegir updated on #131 the test script got broken. It was temporarily fixed by adding `--ts` as follows `aegir test --ts -t node` for Node.js tests. The browser tests fail if they have the same option as described on https://github.com/ipfs/aegir/issues/619 .

As a result of this issue, the release script is also failing. I tried to add the `--ts` option for the release but it fails within the browser tests scope. I added the skip tests option to the release and trigger the tests on the `prerelease` script while we do not fix the underlying issue