### PR TITLE
fix: dns require

### DIFF
--- a/src/resolvers/dns.js
+++ b/src/resolvers/dns.js
@@ -4,6 +4,9 @@ let dns
 
 try {
   dns = require('dns').promises
+  if (!dns) {
+    throw new Error('no dns available')
+  }
 } catch (err) {
   dns = require('dns-over-http-resolver')
 }


### PR DESCRIPTION
For some bundlers (example: parcel), `require('dns')` returns `{}`, which would mean the dns exported implementation was null. This throws an error in that case, so that the fallback implementation is used.