### PR TITLE
chore: make tsconfig valid json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "noEmit": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/index.d.ts", "test/**/*.spec.js", "test/**/*.spec.ts"],
+  "include": ["src/index.d.ts", "test/**/*.spec.js", "test/**/*.spec.ts"]
 }


### PR DESCRIPTION
You can't have trailing commas like this in JSON.

Fixes error `Unexpected token } in JSON at position 458` when trying
to run `npm run build`.