### PR TITLE
fix: tell bundlers to return false for node dns module

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "license": "MIT",
   "bugs": "https://github.com/multiformats/js-multiaddr/issues",
   "homepage": "https://github.com/multiformats/js-multiaddr",
+  "browser": {
+    "dns": false
+  },
   "dependencies": {
     "cids": "^1.0.0",
     "class-is": "^1.1.0",


### PR DESCRIPTION
Silences this sort of warning which [people report as an error](https://github.com/ipfs/js-ipfs/issues/3441):

```
98% after emitting CopyPlugin

 WARNING  Compiled with 1 warning                                         21:06:05

 warning  in ./node_modules/multiaddr/src/resolvers/dns.js

Module not found: Error: Can't resolve 'dns' in '/home/david/dev/group/node_modules/multiaddr/src/resolvers'
```

Closes #156 