### PR TITLE
Support buffer with any byteOffset values instead of 0

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -133,7 +133,7 @@ function port2bytes (port) {
  */
 function bytes2port (buf) {
   const view = new DataView(buf.buffer)
-  return view.getUint16(0)
+  return view.getUint16(buf.byteOffset)
 }
 
 /**

--- a/test/convert.spec.js
+++ b/test/convert.spec.js
@@ -81,5 +81,12 @@ describe('convert', () => {
         'c0a80001'
       )
     })
+
+    it('respects byteoffset during conversion', () => {
+      const bytes = convert.toBytes('sctp', '1234')
+      const buffer = new Uint8Array(bytes.byteLength + 5)
+      buffer.set(bytes, 5)
+      expect(convert.toString('sctp', buffer.subarray(5))).to.equal('1234')
+    })
   })
 })


### PR DESCRIPTION
Supersedes #146. Just adds a test that fails without a fix from @tuyennhv 