### PR TITLE
chore: remove aegir publish commands from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "test:electron-main": "aegir test -t electron-main -f ./dist/test/**/*.js",
     "test:electron-renderer": "aegir test -t electron-renderer -f ./dist/test/**/*.js",
     "lint": "aegir ts -p check && aegir lint",
-    "release": "aegir release --docs",
-    "release-minor": "aegir release --target node --type minor --docs",
-    "release-major": "aegir release --type major --docs",
     "build": "tsc",
     "dep-check": "aegir dep-check dist/src/**/*.js dist/test/**/*.js"
   },


### PR DESCRIPTION
This module uses gh actions for publishing now