### PR TITLE
feat: support ip6zone

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -30,6 +30,8 @@ export function convertToString (proto: number | string, buf: Uint8Array) {
     case 4: // ipv4
     case 41: // ipv6
       return bytes2ip(buf)
+    case 42: // ipv6zone
+      return bytes2str(buf)
 
     case 6: // tcp
     case 273: // udp
@@ -63,6 +65,8 @@ export function convertToBytes (proto: string | number, str: string) {
       return ip2bytes(str)
     case 41: // ipv6
       return ip2bytes(str)
+    case 42: // ipv6zone
+      return str2bytes(str)
 
     case 6: // tcp
     case 273: // udp

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -582,7 +582,7 @@ describe('helpers', () => {
         multiaddr('/ip6zone/x/ip6/fe80::1/tcp/1234').toOptions()
       ).to.be.eql({
         family: 6,
-        host: 'fe80::1',
+        host: 'fe80::1%x',
         transport: 'tcp',
         port: 1234
       })
@@ -833,7 +833,7 @@ describe('helpers', () => {
       expect(
         multiaddr('/ip6zone/x/ip6/fe80::1/tcp/1234').nodeAddress()
       ).to.be.eql({
-        address: 'fe80::1',
+        address: 'fe80::1%x',
         family: 6,
         port: 1234
       })
@@ -892,6 +892,18 @@ describe('helpers', () => {
         }, 'tcp').toString()
       ).to.be.eql(
         '/ip4/192.168.0.1/tcp/1234'
+      )
+    })
+
+    it('parses a node address with an ip6zone', () => {
+      expect(
+        fromNodeAddress({
+          address: 'fe80::1%x',
+          family: 6,
+          port: 1234
+        }, 'tcp').toString()
+      ).to.be.eql(
+        '/ip6zone/x/ip6/fe80::1/tcp/1234'
       )
     })
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -576,6 +576,17 @@ describe('helpers', () => {
           port: 443
         })
     })
+
+    it('returns an options object from an address with an ip6 zone', () => {
+      expect(
+        multiaddr('/ip6zone/x/ip6/fe80::1/tcp/1234').toOptions()
+      ).to.be.eql({
+        family: 6,
+        host: 'fe80::1',
+        transport: 'tcp',
+        port: 1234
+      })
+    })
   })
 
   describe('.protos', () => {
@@ -815,6 +826,16 @@ describe('helpers', () => {
         address: 'bootstrap.libp2p.io',
         family: 4,
         port: 443
+      })
+    })
+
+    it('transforms an address with an ip6 zone', () => {
+      expect(
+        multiaddr('/ip6zone/x/ip6/fe80::1/tcp/1234').nodeAddress()
+      ).to.be.eql({
+        address: 'fe80::1',
+        family: 6,
+        port: 1234
       })
     })
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -241,6 +241,13 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
+  it('ip6 + ip6zone', () => {
+    const str = '/ip6zone/x/ip6/fe80::1'
+    const addr = new Multiaddr(str)
+    expect(addr).to.have.property('bytes')
+    expect(addr.toString()).to.equal(str)
+  })
+
   it.skip('ip4 + dccp', () => {})
   it.skip('ip6 + dccp', () => {})
 
@@ -341,6 +348,13 @@ describe('variants', () => {
 
   it('ip6 + udp + quic + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
+    const addr = new Multiaddr(str)
+    expect(addr).to.have.property('bytes')
+    expect(addr.toString()).to.equal(str)
+  })
+
+  it('ip6 + ip6zone + udp + quic', () => {
+    const str = '/ip6zone/x/ip6/fe80::1/udp/1234/quic'
     const addr = new Multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -244,7 +244,7 @@ describe('variants', () => {
 
   it('ip6 + ip6zone', () => {
     const str = '/ip6zone/x/ip6/fe80::1'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
@@ -391,7 +391,7 @@ describe('variants', () => {
 
   it('ip6 + ip6zone + udp + quic', () => {
     const str = '/ip6zone/x/ip6/fe80::1/udp/1234/quic'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })


### PR DESCRIPTION
Hi! This PR is not yet ready to merge. Some questions need to be clarified. Please look.
- Should be the same test data used here as in [go-multiaddr](https://github.com/multiformats/go-multiaddr/blob/master/multiaddr_test.go#L107)? Or better add more test data?
- Should [Multiaddr.nodeAddress](https://github.com/multiformats/js-multiaddr/blob/master/src/index.ts#L449) also support 'ip6zone'? Currently it will throw on any address with 'ip6zone'.

The specs PR is multiformats/multiaddr#68 for reference.