### PR TITLE
fix: infer type after isMultiaddr call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -552,7 +552,7 @@ export class Multiaddr {
   /**
    * Check if object is a CID instance
    */
-  static isMultiaddr (value: any) {
+  static isMultiaddr (value: any): value is Multiaddr {
     return value instanceof Multiaddr ?? Boolean(value?.[symbol])
   }
 


### PR DESCRIPTION
Give a hint to tsc that the value is a multiaddr.