### PR TITLE
fix: remove instanceof from multiaddr check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -549,7 +549,7 @@ export class Multiaddr {
    * Check if object is a CID instance
    */
   static isMultiaddr (value: any): value is Multiaddr {
-    return value instanceof Multiaddr ?? Boolean(value?.[symbol])
+    return Boolean(value?.[symbol])
   }
 
   /**


### PR DESCRIPTION
Just use the symbol check instead