### PR TITLE
fix: return correct family from toOptions with dns4 MultiAddr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ export class Multiaddr {
     const parsed = this.toString().split('/')
 
     const opts: MultiaddrObject = {
-      family: parsed[1] === 'ip4' ? 4 : 6,
+      family: (parsed[1] === 'ip4' || parsed[1] === 'dns4') ? 4 : 6,
       host: parsed[2],
       transport: parsed[3],
       port: parseInt(parsed[4])

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -486,6 +486,46 @@ describe('helpers', () => {
           port: 1234
         })
     })
+
+    it('returns an options object from a DNS addr', () => {
+      expect(new Multiaddr('/dns4/google.net/tcp/8000').toOptions())
+        .to.eql({
+          family: 4,
+          host: 'google.net',
+          transport: 'tcp',
+          port: 8000
+        })
+    })
+
+    it('returns an options object from a DNS6 addr', () => {
+      expect(new Multiaddr('/dns6/google.net/tcp/8000').toOptions())
+        .to.eql({
+          family: 6,
+          host: 'google.net',
+          transport: 'tcp',
+          port: 8000
+        })
+    })
+
+    it('returns an options object from a DNS addr defaulting to https', () => {
+      expect(new Multiaddr('/dnsaddr/google.net').toOptions())
+        .to.eql({
+          family: 4,
+          host: 'google.net',
+          transport: 'tcp',
+          port: 443
+        })
+    })
+
+    it('returns an options object from a DNS addr with a PeerID defaulting to https', () => {
+      expect(new Multiaddr('/dnsaddr/google.net/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').toOptions())
+        .to.eql({
+          family: 4,
+          host: 'google.net',
+          transport: 'tcp',
+          port: 443
+        })
+    })
   })
 
   describe('.inspect', () => {


### PR DESCRIPTION
When calling toOptions with a dns4 multiaddress, a MultiaddrObject is returned where the ip family is 6 instead of 4. This causes an issue where libp2p is unable to resolve the domain and dial the peer. This only appears to be an issue on some systems. It works on Mac OS but fails on for example Alpine Linux.

Example:
```javascript
const {multiaddr} = require("multiaddr")

console.log(multiaddr('/dns4/google.net/tcp/8000').toOptions())`
```

```javascript
Object {family: 6, host: "google.net", transport: "tcp", port: 8000}
```