### PR TITLE
feat: add convert subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     ".": {
       "import": "./dist/src/index.js"
     },
+    "./convert": {
+      "import": "./dist/src/convert.js"
+    },
     "./resolvers": {
       "import": "./dist/src/resolvers/index.js"
     }


### PR DESCRIPTION
I'd like to convert multiaddr segments to / from bytes in a library that can create multiaddrs.
Creating a full multiaddr wouldn't make sense, nor would reimplementing the conversion logic if it already exists in this library.

Before the ESM version of this library I used multiaddrs/src/convert directly.
See usage of `muConvert` here https://github.com/ChainSafe/discv5/blob/master/src/enr/enr.ts
