### PR TITLE
feat!: remove inspect symbol from public interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -581,9 +581,7 @@ export class Multiaddr {
    * ```
    */
   inspect () {
-    return '<Multiaddr ' +
-      uint8ArrayToString(this.bytes, 'base16') + ' - ' +
-      codec.bytesToString(this.bytes) + '>'
+    return this[inspect]()
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -563,7 +563,7 @@ export class Multiaddr {
    * // '<Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>'
    * ```
    */
-  [inspect] () {
+  private [inspect] () {
     return '<Multiaddr ' +
     uint8ArrayToString(this.bytes, 'base16') + ' - ' +
     codec.bytesToString(this.bytes) + '>'


### PR DESCRIPTION
The inspect symbol being part of the public interfaces causes type incompatibilities between otherwise compatible versions of this library.
Typescript treats the symbol as unique, even though the same symbol will be used across versions.

Eg:
Library A uses @multiformats/multiaddr@1.1.8
Library B uses A and @multiformats/multiaddr@1.2.0

The types will not match and there will be a type error:
```
error TS2741: Property '[inspect]' is missing in type 'import("/path/to/B/node_modules/@multiformats/multiaddr/dist/src/index").Multiaddr' but required in type 'import("/path/to/B/node_modules/A/node_modules/@multiformats/multiaddr/dist/src/index").Multiaddr'.
```