### PR TITLE
feat: allow cacelling in-flight multiaddr resolve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,11 @@ export interface NodeAddress {
 
 export type MultiaddrInput = string | Multiaddr | Uint8Array | null
 
-export interface Resolver { (addr: Multiaddr): Promise<string[]> }
+export interface Resolver { (addr: Multiaddr, options?: AbortOptions): Promise<string[]> }
+
+export interface AbortOptions {
+  signal?: AbortSignal
+}
 
 const resolvers = new Map<string, Resolver>()
 const symbol = Symbol.for('@multiformats/js-multiaddr/multiaddr')
@@ -421,7 +425,7 @@ export class Multiaddr {
    * // ]
    * ```
    */
-  async resolve () {
+  async resolve (options?: AbortOptions) {
     const resolvableProto = this.protos().find((p) => p.resolvable)
 
     // Multiaddr is not resolvable?
@@ -434,7 +438,7 @@ export class Multiaddr {
       throw errCode(new Error(`no available resolver for ${resolvableProto.name}`), 'ERR_NO_AVAILABLE_RESOLVER')
     }
 
-    const addresses = await resolver(this)
+    const addresses = await resolver(this, options)
     return addresses.map((a) => new Multiaddr(a))
   }
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,14 +1,20 @@
 import { getProtocol } from '../protocols-table.js'
 import Resolver from './dns.js'
-import type { Multiaddr } from '../index.js'
+import type { AbortOptions, Multiaddr } from '../index.js'
 
 const { code: dnsaddrCode } = getProtocol('dnsaddr')
 
 /**
  * Resolver for dnsaddr addresses.
  */
-export async function dnsaddrResolver (addr: Multiaddr) {
+export async function dnsaddrResolver (addr: Multiaddr, options: AbortOptions = {}) {
   const resolver = new Resolver()
+
+  if (options.signal != null) {
+    options.signal.addEventListener('abort', () => {
+      resolver.cancel()
+    })
+  }
 
   const peerId = addr.getPeerId()
   const [, hostname] = addr.stringTuples().find(([proto]) => proto === dnsaddrCode) ?? []
@@ -18,6 +24,7 @@ export async function dnsaddrResolver (addr: Multiaddr) {
   }
 
   const records = await resolver.resolveTxt(`_dnsaddr.${hostname}`)
+
   let addresses = records.flat().map((a) => a.split('=')[1])
 
   if (peerId != null) {

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -97,5 +97,19 @@ describe('multiaddr resolve', () => {
         expect(ma.equals(new Multiaddr(stubAddr))).to.equal(true)
       })
     })
+
+    it('can cancel resolving', async () => {
+      const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nc')
+      const controller = new AbortController()
+
+      // Resolve
+      const resolvePromise = ma.resolve({
+        signal: controller.signal
+      })
+
+      controller.abort()
+
+      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ECANCELLED')
+    })
   })
 })


### PR DESCRIPTION
Doing a multiaddr resolve involves a DNS request which can be very slow, so allow aborting the request before it's resolved.