### PR TITLE
fix: trim string before parsing IP address

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -103,7 +103,7 @@ const anybaseDecoder = (function () {
 
 function ip2bytes (ipString: string) {
   if (!ip.isIP(ipString)) {
-    throw new Error('invalid ip address')
+    throw new Error(`invalid ip address "${ipString}"`)
   }
   return ip.toBytes(ipString)
 }

--- a/src/ip.ts
+++ b/src/ip.ts
@@ -57,7 +57,7 @@ export const toBytes = function (ip: string): Uint8Array {
   }
 
   if (result == null) {
-    throw Error('Invalid ip address: ' + ip)
+    throw new Error(`invalid ip address "${ip}"`)
   }
 
   return result

--- a/src/ip.ts
+++ b/src/ip.ts
@@ -10,6 +10,7 @@ export const isV6 = isIPv6
 export const toBytes = function (ip: string): Uint8Array {
   let offset = 0
   let result
+  ip = ip.trim()
 
   if (isV4(ip)) {
     result = new Uint8Array(offset + 4)
@@ -63,7 +64,7 @@ export const toBytes = function (ip: string): Uint8Array {
 }
 
 // Copied from https://github.com/indutny/node-ip/blob/master/lib/ip.js#L63
-export const toString = function (buf: Uint8Array, offset: number, length: number) {
+export const toString = function (buf: Uint8Array, offset: number = 0, length?: number) {
   offset = ~~offset
   length = length ?? (buf.length - offset)
 

--- a/test/ip.spec.ts
+++ b/test/ip.spec.ts
@@ -1,0 +1,29 @@
+/* eslint max-nested-callbacks: ["error", 8] */
+/* eslint-env mocha */
+import { expect } from 'aegir/chai'
+import { toBytes, toString } from '../src/ip.js'
+
+describe('ip', () => {
+  describe('toBytes', () => {
+    it('should handle extra characters', () => {
+      const address = '127.0.0.1 '
+      const bytes = toBytes(address)
+
+      expect(toString(bytes)).to.equal(address.trim())
+    })
+
+    it('should turn loopback into bytes', () => {
+      const address = '127.0.0.1'
+      const bytes = toBytes(address)
+
+      expect(toString(bytes)).to.equal(address)
+    })
+
+    it('should turn private address into bytes', () => {
+      const address = '192.168.1.1'
+      const bytes = toBytes(address)
+
+      expect(toString(bytes)).to.equal(address)
+    })
+  })
+})


### PR DESCRIPTION
Remove leading and training spaces, also adds tests.