### PR TITLE
fix: fix converting strings to IP addresses and back again

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -103,7 +103,7 @@ const anybaseDecoder = (function () {
 
 function ip2bytes (ipString: string) {
   if (!ip.isIP(ipString)) {
-    throw new Error(`invalid ip address "${ipString}"`)
+    throw new Error('invalid ip address')
   }
   return ip.toBytes(ipString)
 }
@@ -114,7 +114,7 @@ function bytes2ip (ipBuff: Uint8Array) {
     throw new Error('ipBuff is required')
   }
   if (!ip.isIP(ipString)) {
-    throw new Error(`invalid ip address "${ipString}"`)
+    throw new Error('invalid ip address')
   }
   return ipString
 }


### PR DESCRIPTION
Partial fix for the issues observed in the ipfs interop suite - windows seems to lose it's reference to the `results` variable during node startup, but only windows.  Instead return the result from the scope in which is is created.

A follow up will be needed to address the other windows problem which is the IP detection regex seems to stop working.  Might be a bug in node I guess?