### PR TITLE
feat!: convert to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
-- [Lead Maintainer](#lead-maintainer)
 - [Background](#background)
   - [What is multiaddr?](#what-is-multiaddr)
   - [Browser: `<script>` Tag](#browser-script-tag)
@@ -24,10 +23,6 @@
 ```console
 $ npm i @multiformats/multiaddr
 ```
-
-## Lead Maintainer
-
-[Jacob Heun](https://github.com/jacobheun)
 
 ## Background
 
@@ -57,15 +52,11 @@ the global namespace.
 ## Usage
 
 ```js
-// if we are coming from <= 8.x you can use the factory function
-const { multiaddr } = require('multiaddr')
+import { multiaddr } from 'multiaddr'
 const addr =  multiaddr("/ip4/127.0.0.1/udp/1234")
 // <Multiaddr /ip4/127.0.0.1/udp/1234>
 
-// or just the class directly
-const { Multiaddr } = require('multiaddr')
-
-const addr = new Multiaddr("/ip4/127.0.0.1/udp/1234")
+const addr = multiaddr("/ip4/127.0.0.1/udp/1234")
 // <Multiaddr /ip4/127.0.0.1/udp/1234>
 
 addr.bytes
@@ -106,10 +97,9 @@ addr.encapsulate('/sctp/5678')
 To provide multiaddr resolvers you can do:
 
 ```js
-const { Multiaddr } = require('multiaddr')
-const resolvers = require('multiaddr/src/resolvers')
+import { resolvers  } from 'multiaddr'
 
-Multiaddr.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
 ```
 
 The available resolvers are:

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,17 @@ export interface Multiaddr {
   bytes: Uint8Array
 
   /**
+   * Returns Multiaddr as a String
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').toString()
+   * // '/ip4/127.0.0.1/tcp/4001'
+   * ```
+   */
+  toString: () => string
+
+  /**
    * Returns Multiaddr as a JSON encoded object
    *
    * @example
@@ -65,7 +76,7 @@ export interface Multiaddr {
    * // '/ip4/127.0.0.1/tcp/4001'
    * ```
    */
-  toJSON (): string
+  toJSON: () => string
 
   /**
    * Returns Multiaddr as a convinient options object to be used with net.createConnection
@@ -76,7 +87,7 @@ export interface Multiaddr {
    * // { family: 4, host: '127.0.0.1', transport: 'tcp', port: 4001 }
    * ```
    */
-  toOptions (): MultiaddrObject
+  toOptions: () => MultiaddrObject
 
   /**
    * Returns the protocols the Multiaddr is defined with, as an array of objects, in
@@ -91,7 +102,7 @@ export interface Multiaddr {
    * //   { code: 6, size: 16, name: 'tcp' } ]
    * ```
    */
-  protos (): Protocol[]
+  protos: () => Protocol[]
 
   /**
    * Returns the codes of the protocols in left-to-right order.
@@ -103,7 +114,7 @@ export interface Multiaddr {
    * // [ 4, 6 ]
    * ```
    */
-  protoCodes (): number[]
+  protoCodes: () => number[]
 
   /**
    * Returns the names of the protocols in left-to-right order.
@@ -115,7 +126,7 @@ export interface Multiaddr {
    * // [ 'ip4', 'tcp' ]
    * ```
    */
-  protoNames (): string[]
+  protoNames: () => string[]
 
   /**
    * Returns a tuple of parts
@@ -126,7 +137,7 @@ export interface Multiaddr {
    * // [ [ 4, <Buffer 7f 00 00 01> ], [ 6, <Buffer 0f a1> ] ]
    * ```
    */
-  tuples (): Array<[number, Uint8Array?]>
+  tuples: () => Array<[number, Uint8Array?]>
 
   /**
    * Returns a tuple of string/number parts
@@ -139,7 +150,7 @@ export interface Multiaddr {
    * // [ [ 4, '127.0.0.1' ], [ 6, '4001' ] ]
    * ```
    */
-  stringTuples (): Array<[number, string?]>
+  stringTuples: () => Array<[number, string?]>
 
   /**
    * Encapsulates a Multiaddr in another Multiaddr
@@ -161,7 +172,7 @@ export interface Multiaddr {
    *
    * @param {MultiaddrInput} addr - Multiaddr to add into this Multiaddr
    */
-  encapsulate (addr: MultiaddrInput): Multiaddr
+  encapsulate: (addr: MultiaddrInput) => Multiaddr
 
   /**
    * Decapsulates a Multiaddr from another Multiaddr
@@ -183,7 +194,7 @@ export interface Multiaddr {
    *
    * @param {Multiaddr | string} addr - Multiaddr to remove from this Multiaddr
    */
-  decapsulate (addr: Multiaddr | string): Multiaddr
+  decapsulate: (addr: Multiaddr | string) => Multiaddr
 
   /**
    * A more reliable version of `decapsulate` if you are targeting a
@@ -203,7 +214,7 @@ export interface Multiaddr {
    * // '/ip4/127.0.0.1/tcp/8080'
    * ```
    */
-  decapsulateCode (code: number): Multiaddr
+  decapsulateCode: (code: number) => Multiaddr
 
   /**
    * Extract the peerId if the multiaddr contains one
@@ -217,7 +228,7 @@ export interface Multiaddr {
    * const peerId = mh1.getPeerId()
    * ```
    */
-  getPeerId (): string | null
+  getPeerId: () => string | null
 
   /**
    * Extract the path if the multiaddr contains one
@@ -231,7 +242,7 @@ export interface Multiaddr {
    * const path = mh1.getPath()
    * ```
    */
-  getPath (): string | null
+  getPath: () => string | null
 
   /**
    * Checks if two Multiaddrs are the same
@@ -251,7 +262,7 @@ export interface Multiaddr {
    * // false
    * ```
    */
-  equals (addr: { bytes: Uint8Array }): boolean
+  equals: (addr: { bytes: Uint8Array }) => boolean
 
   /**
    * Resolve multiaddr if containing resolvable hostname.
@@ -268,7 +279,7 @@ export interface Multiaddr {
    * // ]
    * ```
    */
-  resolve (options?: AbortOptions): Promise<Multiaddr[]>
+  resolve: (options?: AbortOptions) => Promise<Multiaddr[]>
 
   /**
    * Gets a Multiaddrs node-friendly address object. Note that protocol information
@@ -283,7 +294,7 @@ export interface Multiaddr {
    * // {family: 4, address: '127.0.0.1', port: 4001}
    * ```
    */
-  nodeAddress (): NodeAddress
+  nodeAddress: () => NodeAddress
 
   /**
    * Returns if a Multiaddr is a Thin Waist address or not.
@@ -312,7 +323,7 @@ export interface Multiaddr {
    * // false
    * ```
    */
-  isThinWaistAddress (addr?: Multiaddr): boolean
+  isThinWaistAddress: (addr?: Multiaddr) => boolean
 
   /**
    * Returns Multiaddr as a human-readable string.
@@ -325,9 +336,8 @@ export interface Multiaddr {
    * // '<Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>'
    * ```
    */
-  inspect (): string
+  inspect: () => string
 }
-
 
 /**
  * Creates a Multiaddr from a node-friendly address object
@@ -418,41 +428,14 @@ class DefaultMultiaddr implements Multiaddr {
     }
   }
 
-  /**
-   * Returns Multiaddr as a String
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').toString()
-   * // '/ip4/127.0.0.1/tcp/4001'
-   * ```
-   */
   toString () {
     return codec.bytesToString(this.bytes)
   }
 
-  /**
-   * Returns Multiaddr as a JSON encoded object
-   *
-   * @example
-   * ```js
-   * JSON.stringify(new Multiaddr('/ip4/127.0.0.1/tcp/4001'))
-   * // '/ip4/127.0.0.1/tcp/4001'
-   * ```
-   */
   toJSON () {
     return this.toString()
   }
 
-  /**
-   * Returns Multiaddr as a convinient options object to be used with net.createConnection
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').toOptions()
-   * // { family: 4, host: '127.0.0.1', transport: 'tcp', port: 4001 }
-   * ```
-   */
   toOptions (): MultiaddrObject {
     const codes = this.protoCodes()
     const parts = this.toString().split('/').slice(1)
@@ -485,34 +468,11 @@ class DefaultMultiaddr implements Multiaddr {
     return opts
   }
 
-  /**
-   * Returns the protocols the Multiaddr is defined with, as an array of objects, in
-   * left-to-right order. Each object contains the protocol code, protocol name,
-   * and the size of its address space in bits.
-   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').protos()
-   * // [ { code: 4, size: 32, name: 'ip4' },
-   * //   { code: 6, size: 16, name: 'tcp' } ]
-   * ```
-   */
-  protos () {
+  protos (): Protocol[] {
     return this.protoCodes().map(code => Object.assign({}, getProtocol(code)))
   }
 
-  /**
-   * Returns the codes of the protocols in left-to-right order.
-   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
-   *
-   * @example
-   * ```js
-   * Multiaddr('/ip4/127.0.0.1/tcp/4001').protoCodes()
-   * // [ 4, 6 ]
-   * ```
-   */
-  protoCodes () {
+  protoCodes (): number[] {
     const codes: number[] = []
     const buf = this.bytes
     let i = 0
@@ -530,95 +490,25 @@ class DefaultMultiaddr implements Multiaddr {
     return codes
   }
 
-  /**
-   * Returns the names of the protocols in left-to-right order.
-   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').protoNames()
-   * // [ 'ip4', 'tcp' ]
-   * ```
-   */
-  protoNames () {
+  protoNames (): string[] {
     return this.protos().map(proto => proto.name)
   }
 
-  /**
-   * Returns a tuple of parts
-   *
-   * @example
-   * ```js
-   * new Multiaddr("/ip4/127.0.0.1/tcp/4001").tuples()
-   * // [ [ 4, <Buffer 7f 00 00 01> ], [ 6, <Buffer 0f a1> ] ]
-   * ```
-   */
-  tuples () {
+  tuples (): Array<[number, Uint8Array?]> {
     return codec.bytesToTuples(this.bytes)
   }
 
-  /**
-   * Returns a tuple of string/number parts
-   * - tuples[][0] = code of protocol
-   * - tuples[][1] = contents of address
-   *
-   * @example
-   * ```js
-   * new Multiaddr("/ip4/127.0.0.1/tcp/4001").stringTuples()
-   * // [ [ 4, '127.0.0.1' ], [ 6, '4001' ] ]
-   * ```
-   */
-  stringTuples () {
+  stringTuples (): Array<[number, string?]> {
     const t = codec.bytesToTuples(this.bytes)
     return codec.tuplesToStringTuples(t)
   }
 
-  /**
-   * Encapsulates a Multiaddr in another Multiaddr
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
-   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
-   *
-   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
-   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
-   *
-   * const mh3 = mh1.encapsulate(mh2)
-   * // <Multiaddr 0408080808060438047f000001060fa1 - /ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001>
-   *
-   * mh3.toString()
-   * // '/ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001'
-   * ```
-   *
-   * @param {MultiaddrInput} addr - Multiaddr to add into this Multiaddr
-   */
   encapsulate (addr: MultiaddrInput): Multiaddr {
     addr = new DefaultMultiaddr(addr)
     return new DefaultMultiaddr(this.toString() + addr.toString())
   }
 
-  /**
-   * Decapsulates a Multiaddr from another Multiaddr
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
-   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
-   *
-   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
-   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
-   *
-   * const mh3 = mh1.encapsulate(mh2)
-   * // <Multiaddr 0408080808060438047f000001060fa1 - /ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001>
-   *
-   * mh3.decapsulate(mh2).toString()
-   * // '/ip4/8.8.8.8/tcp/1080'
-   * ```
-   *
-   * @param {Multiaddr | string} addr - Multiaddr to remove from this Multiaddr
-   */
-  decapsulate (addr: Multiaddr | string) {
+  decapsulate (addr: Multiaddr | string): Multiaddr {
     const addrString = addr.toString()
     const s = this.toString()
     const i = s.lastIndexOf(addrString)
@@ -628,25 +518,7 @@ class DefaultMultiaddr implements Multiaddr {
     return new DefaultMultiaddr(s.slice(0, i))
   }
 
-  /**
-   * A more reliable version of `decapsulate` if you are targeting a
-   * specific code, such as 421 (the `p2p` protocol code). The last index of the code
-   * will be removed from the `Multiaddr`, and a new instance will be returned.
-   * If the code is not present, the original `Multiaddr` is returned.
-   *
-   * @example
-   * ```js
-   * const addr = new Multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
-   * // <Multiaddr 0400... - /ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC>
-   *
-   * addr.decapsulateCode(421).toString()
-   * // '/ip4/0.0.0.0/tcp/8080'
-   *
-   * new Multiaddr('/ip4/127.0.0.1/tcp/8080').decapsulateCode(421).toString()
-   * // '/ip4/127.0.0.1/tcp/8080'
-   * ```
-   */
-  decapsulateCode (code: number) {
+  decapsulateCode (code: number): Multiaddr {
     const tuples = this.tuples()
     for (let i = tuples.length - 1; i >= 0; i--) {
       if (tuples[i][0] === code) {
@@ -656,18 +528,6 @@ class DefaultMultiaddr implements Multiaddr {
     return this
   }
 
-  /**
-   * Extract the peerId if the multiaddr contains one
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080/ipfs/QmValidBase58string')
-   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080/ipfs/QmValidBase58string>
-   *
-   * // should return QmValidBase58string or null if the id is missing or invalid
-   * const peerId = mh1.getPeerId()
-   * ```
-   */
   getPeerId (): string | null {
     try {
       const tuples = this.stringTuples().filter((tuple) => {
@@ -698,18 +558,6 @@ class DefaultMultiaddr implements Multiaddr {
     }
   }
 
-  /**
-   * Extract the path if the multiaddr contains one
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock')
-   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock>
-   *
-   * // should return utf8 string or null if the id is missing or invalid
-   * const path = mh1.getPath()
-   * ```
-   */
   getPath (): string | null {
     let path = null
     try {
@@ -730,44 +578,11 @@ class DefaultMultiaddr implements Multiaddr {
     return path
   }
 
-  /**
-   * Checks if two Multiaddrs are the same
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
-   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
-   *
-   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
-   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
-   *
-   * mh1.equals(mh1)
-   * // true
-   *
-   * mh1.equals(mh2)
-   * // false
-   * ```
-   */
   equals (addr: { bytes: Uint8Array }) {
     return uint8ArrayEquals(this.bytes, addr.bytes)
   }
 
-  /**
-   * Resolve multiaddr if containing resolvable hostname.
-   *
-   * @example
-   * ```js
-   * Multiaddr.resolvers.set('dnsaddr', resolverFunction)
-   * const mh1 = new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
-   * const resolvedMultiaddrs = await mh1.resolve()
-   * // [
-   * //   <Multiaddr 04934b5353060fa1a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>,
-   * //   <Multiaddr 04934b53530601bbde03a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>,
-   * //   <Multiaddr 04934b535391020fa1cc03a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>
-   * // ]
-   * ```
-   */
-  async resolve (options?: AbortOptions) {
+  async resolve (options?: AbortOptions): Promise<Multiaddr[]> {
     const resolvableProto = this.protos().find((p) => p.resolvable)
 
     // Multiaddr is not resolvable?
@@ -784,19 +599,6 @@ class DefaultMultiaddr implements Multiaddr {
     return addresses.map((a) => new DefaultMultiaddr(a))
   }
 
-  /**
-   * Gets a Multiaddrs node-friendly address object. Note that protocol information
-   * is left out: in Node (and most network systems) the protocol is unknowable
-   * given only the address.
-   *
-   * Has to be a ThinWaist Address, otherwise throws error
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').nodeAddress()
-   * // {family: 4, address: '127.0.0.1', port: 4001}
-   * ```
-   */
   nodeAddress (): NodeAddress {
     const options = this.toOptions()
 
@@ -811,33 +613,6 @@ class DefaultMultiaddr implements Multiaddr {
     }
   }
 
-  /**
-   * Returns if a Multiaddr is a Thin Waist address or not.
-   *
-   * Thin Waist is if a Multiaddr adheres to the standard combination of:
-   *
-   * `{IPv4, IPv6}/{TCP, UDP}`
-   *
-   * @example
-   * ```js
-   * const mh1 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
-   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
-   * const mh2 = new Multiaddr('/ip4/192.168.2.1/tcp/5001')
-   * // <Multiaddr 04c0a80201061389 - /ip4/192.168.2.1/tcp/5001>
-   * const mh3 = mh1.encapsulate(mh2)
-   * // <Multiaddr 047f000001060fa104c0a80201061389 - /ip4/127.0.0.1/tcp/4001/ip4/192.168.2.1/tcp/5001>
-   * const mh4 = new Multiaddr('/ip4/127.0.0.1/tcp/2000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
-   * // <Multiaddr 047f0000010607d0de039302a503221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a64835843 - /ip4/127.0.0.1/tcp/2000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a>
-   * mh1.isThinWaistAddress()
-   * // true
-   * mh2.isThinWaistAddress()
-   * // true
-   * mh3.isThinWaistAddress()
-   * // false
-   * mh4.isThinWaistAddress()
-   * // false
-   * ```
-   */
   isThinWaistAddress (addr?: Multiaddr) {
     const protos = (addr ?? this).protos()
 
@@ -869,17 +644,6 @@ class DefaultMultiaddr implements Multiaddr {
     return this.inspect()
   }
 
-  /**
-   * Returns Multiaddr as a human-readable string.
-   * Fallback for pre Node.js v10.0.0.
-   * https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect
-   *
-   * @example
-   * ```js
-   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').inspect()
-   * // '<Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>'
-   * ```
-   */
   inspect () {
     return '<Multiaddr ' +
       uint8ArrayToString(this.bytes, 'base16') + ' - ' +
@@ -889,6 +653,14 @@ class DefaultMultiaddr implements Multiaddr {
 
 /**
  * Static factory
+ *
+ * @example
+ * ```js
+ * new Multiaddr('/ip4/127.0.0.1/tcp/4001')
+ * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+ * ```
+ *
+ * @param {MultiaddrInput} [addr] - If String or Uint8Array, needs to adhere to the address format of a [multiaddr](https://github.com/multiformats/multiaddr#string-format)
  */
 export function multiaddr (addr?: MultiaddrInput): Multiaddr {
   return new DefaultMultiaddr(addr)

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,8 +50,333 @@ export interface AbortOptions {
   signal?: AbortSignal
 }
 
-const resolvers = new Map<string, Resolver>()
+export const resolvers = new Map<string, Resolver>()
 const symbol = Symbol.for('@multiformats/js-multiaddr/multiaddr')
+
+export interface Multiaddr {
+  bytes: Uint8Array
+
+  /**
+   * Returns Multiaddr as a JSON encoded object
+   *
+   * @example
+   * ```js
+   * JSON.stringify(new Multiaddr('/ip4/127.0.0.1/tcp/4001'))
+   * // '/ip4/127.0.0.1/tcp/4001'
+   * ```
+   */
+  toJSON (): string
+
+  /**
+   * Returns Multiaddr as a convinient options object to be used with net.createConnection
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').toOptions()
+   * // { family: 4, host: '127.0.0.1', transport: 'tcp', port: 4001 }
+   * ```
+   */
+  toOptions (): MultiaddrObject
+
+  /**
+   * Returns the protocols the Multiaddr is defined with, as an array of objects, in
+   * left-to-right order. Each object contains the protocol code, protocol name,
+   * and the size of its address space in bits.
+   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').protos()
+   * // [ { code: 4, size: 32, name: 'ip4' },
+   * //   { code: 6, size: 16, name: 'tcp' } ]
+   * ```
+   */
+  protos (): Protocol[]
+
+  /**
+   * Returns the codes of the protocols in left-to-right order.
+   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
+   *
+   * @example
+   * ```js
+   * Multiaddr('/ip4/127.0.0.1/tcp/4001').protoCodes()
+   * // [ 4, 6 ]
+   * ```
+   */
+  protoCodes (): number[]
+
+  /**
+   * Returns the names of the protocols in left-to-right order.
+   * [See list of protocols](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').protoNames()
+   * // [ 'ip4', 'tcp' ]
+   * ```
+   */
+  protoNames (): string[]
+
+  /**
+   * Returns a tuple of parts
+   *
+   * @example
+   * ```js
+   * new Multiaddr("/ip4/127.0.0.1/tcp/4001").tuples()
+   * // [ [ 4, <Buffer 7f 00 00 01> ], [ 6, <Buffer 0f a1> ] ]
+   * ```
+   */
+  tuples (): Array<[number, Uint8Array?]>
+
+  /**
+   * Returns a tuple of string/number parts
+   * - tuples[][0] = code of protocol
+   * - tuples[][1] = contents of address
+   *
+   * @example
+   * ```js
+   * new Multiaddr("/ip4/127.0.0.1/tcp/4001").stringTuples()
+   * // [ [ 4, '127.0.0.1' ], [ 6, '4001' ] ]
+   * ```
+   */
+  stringTuples (): Array<[number, string?]>
+
+  /**
+   * Encapsulates a Multiaddr in another Multiaddr
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
+   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
+   *
+   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
+   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+   *
+   * const mh3 = mh1.encapsulate(mh2)
+   * // <Multiaddr 0408080808060438047f000001060fa1 - /ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001>
+   *
+   * mh3.toString()
+   * // '/ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001'
+   * ```
+   *
+   * @param {MultiaddrInput} addr - Multiaddr to add into this Multiaddr
+   */
+  encapsulate (addr: MultiaddrInput): Multiaddr
+
+  /**
+   * Decapsulates a Multiaddr from another Multiaddr
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
+   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
+   *
+   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
+   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+   *
+   * const mh3 = mh1.encapsulate(mh2)
+   * // <Multiaddr 0408080808060438047f000001060fa1 - /ip4/8.8.8.8/tcp/1080/ip4/127.0.0.1/tcp/4001>
+   *
+   * mh3.decapsulate(mh2).toString()
+   * // '/ip4/8.8.8.8/tcp/1080'
+   * ```
+   *
+   * @param {Multiaddr | string} addr - Multiaddr to remove from this Multiaddr
+   */
+  decapsulate (addr: Multiaddr | string): Multiaddr
+
+  /**
+   * A more reliable version of `decapsulate` if you are targeting a
+   * specific code, such as 421 (the `p2p` protocol code). The last index of the code
+   * will be removed from the `Multiaddr`, and a new instance will be returned.
+   * If the code is not present, the original `Multiaddr` is returned.
+   *
+   * @example
+   * ```js
+   * const addr = new Multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+   * // <Multiaddr 0400... - /ip4/0.0.0.0/tcp/8080/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC>
+   *
+   * addr.decapsulateCode(421).toString()
+   * // '/ip4/0.0.0.0/tcp/8080'
+   *
+   * new Multiaddr('/ip4/127.0.0.1/tcp/8080').decapsulateCode(421).toString()
+   * // '/ip4/127.0.0.1/tcp/8080'
+   * ```
+   */
+  decapsulateCode (code: number): Multiaddr
+
+  /**
+   * Extract the peerId if the multiaddr contains one
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080/ipfs/QmValidBase58string')
+   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080/ipfs/QmValidBase58string>
+   *
+   * // should return QmValidBase58string or null if the id is missing or invalid
+   * const peerId = mh1.getPeerId()
+   * ```
+   */
+  getPeerId (): string | null
+
+  /**
+   * Extract the path if the multiaddr contains one
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock')
+   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080/unix/tmp/p2p.sock>
+   *
+   * // should return utf8 string or null if the id is missing or invalid
+   * const path = mh1.getPath()
+   * ```
+   */
+  getPath (): string | null
+
+  /**
+   * Checks if two Multiaddrs are the same
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/8.8.8.8/tcp/1080')
+   * // <Multiaddr 0408080808060438 - /ip4/8.8.8.8/tcp/1080>
+   *
+   * const mh2 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
+   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+   *
+   * mh1.equals(mh1)
+   * // true
+   *
+   * mh1.equals(mh2)
+   * // false
+   * ```
+   */
+  equals (addr: { bytes: Uint8Array }): boolean
+
+  /**
+   * Resolve multiaddr if containing resolvable hostname.
+   *
+   * @example
+   * ```js
+   * Multiaddr.resolvers.set('dnsaddr', resolverFunction)
+   * const mh1 = new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+   * const resolvedMultiaddrs = await mh1.resolve()
+   * // [
+   * //   <Multiaddr 04934b5353060fa1a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>,
+   * //   <Multiaddr 04934b53530601bbde03a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>,
+   * //   <Multiaddr 04934b535391020fa1cc03a503221220c10f9319dac35c270a6b74cd644cb3acfc1f6efc8c821f8eb282599fd1814f64 - /ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb>
+   * // ]
+   * ```
+   */
+  resolve (options?: AbortOptions): Promise<Multiaddr[]>
+
+  /**
+   * Gets a Multiaddrs node-friendly address object. Note that protocol information
+   * is left out: in Node (and most network systems) the protocol is unknowable
+   * given only the address.
+   *
+   * Has to be a ThinWaist Address, otherwise throws error
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').nodeAddress()
+   * // {family: 4, address: '127.0.0.1', port: 4001}
+   * ```
+   */
+  nodeAddress (): NodeAddress
+
+  /**
+   * Returns if a Multiaddr is a Thin Waist address or not.
+   *
+   * Thin Waist is if a Multiaddr adheres to the standard combination of:
+   *
+   * `{IPv4, IPv6}/{TCP, UDP}`
+   *
+   * @example
+   * ```js
+   * const mh1 = new Multiaddr('/ip4/127.0.0.1/tcp/4001')
+   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+   * const mh2 = new Multiaddr('/ip4/192.168.2.1/tcp/5001')
+   * // <Multiaddr 04c0a80201061389 - /ip4/192.168.2.1/tcp/5001>
+   * const mh3 = mh1.encapsulate(mh2)
+   * // <Multiaddr 047f000001060fa104c0a80201061389 - /ip4/127.0.0.1/tcp/4001/ip4/192.168.2.1/tcp/5001>
+   * const mh4 = new Multiaddr('/ip4/127.0.0.1/tcp/2000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a')
+   * // <Multiaddr 047f0000010607d0de039302a503221220d52ebb89d85b02a284948203a62ff28389c57c9f42beec4ec20db76a64835843 - /ip4/127.0.0.1/tcp/2000/wss/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSooo2a>
+   * mh1.isThinWaistAddress()
+   * // true
+   * mh2.isThinWaistAddress()
+   * // true
+   * mh3.isThinWaistAddress()
+   * // false
+   * mh4.isThinWaistAddress()
+   * // false
+   * ```
+   */
+  isThinWaistAddress (addr?: Multiaddr): boolean
+
+  /**
+   * Returns Multiaddr as a human-readable string.
+   * Fallback for pre Node.js v10.0.0.
+   * https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect
+   *
+   * @example
+   * ```js
+   * new Multiaddr('/ip4/127.0.0.1/tcp/4001').inspect()
+   * // '<Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>'
+   * ```
+   */
+  inspect (): string
+}
+
+
+/**
+ * Creates a Multiaddr from a node-friendly address object
+ *
+ * @example
+ * ```js
+ * Multiaddr.fromNodeAddress({address: '127.0.0.1', port: '4001'}, 'tcp')
+ * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
+ * ```
+ */
+export function fromNodeAddress (addr: NodeAddress, transport: string): Multiaddr {
+  if (addr == null) {
+    throw new Error('requires node address object')
+  }
+  if (transport == null) {
+    throw new Error('requires transport protocol')
+  }
+  let ip
+  switch (addr.family) {
+    case 4:
+      ip = 'ip4'
+      break
+    case 6:
+      ip = 'ip6'
+      break
+    default:
+      throw Error('Invalid addr family, should be 4 or 6.')
+  }
+  return new DefaultMultiaddr('/' + [ip, addr.address, transport, addr.port].join('/'))
+}
+
+/**
+ * Returns if something is a Multiaddr that is a name
+ */
+export function isName (addr: Multiaddr): boolean {
+  if (!isMultiaddr(addr)) {
+    return false
+  }
+
+  // if a part of the multiaddr is resolvable, then return true
+  return addr.protos().some((proto) => proto.resolvable)
+}
+
+/**
+ * Check if object is a CID instance
+ */
+export function isMultiaddr (value: any): value is Multiaddr {
+  return Boolean(value?.[symbol])
+}
 
 /**
  * Creates a [multiaddr](https://github.com/multiformats/multiaddr) from
@@ -59,10 +384,10 @@ const symbol = Symbol.for('@multiformats/js-multiaddr/multiaddr')
  * public key.
  *
  */
-export class Multiaddr {
-  static resolvers = resolvers
-
+class DefaultMultiaddr implements Multiaddr {
   public bytes: Uint8Array
+
+  [symbol]: boolean = true
 
   /**
    * @example
@@ -79,9 +404,6 @@ export class Multiaddr {
       addr = ''
     }
 
-    // Define symbol
-    Object.defineProperty(this, symbol, { value: true })
-
     if (addr instanceof Uint8Array) {
       this.bytes = codec.fromBytes(addr)
     } else if (typeof addr === 'string') {
@@ -89,7 +411,7 @@ export class Multiaddr {
         throw new Error(`multiaddr "${addr}" must start with a "/"`)
       }
       this.bytes = codec.fromString(addr)
-    } else if (Multiaddr.isMultiaddr(addr)) { // Multiaddr
+    } else if (isMultiaddr(addr)) { // Multiaddr
       this.bytes = codec.fromBytes(addr.bytes) // validate + copy buffer
     } else {
       throw new Error('addr must be a string, Buffer, or another Multiaddr')
@@ -271,9 +593,9 @@ export class Multiaddr {
    *
    * @param {MultiaddrInput} addr - Multiaddr to add into this Multiaddr
    */
-  encapsulate (addr: MultiaddrInput) {
-    addr = new Multiaddr(addr)
-    return new Multiaddr(this.toString() + addr.toString())
+  encapsulate (addr: MultiaddrInput): Multiaddr {
+    addr = new DefaultMultiaddr(addr)
+    return new DefaultMultiaddr(this.toString() + addr.toString())
   }
 
   /**
@@ -303,7 +625,7 @@ export class Multiaddr {
     if (i < 0) {
       throw new Error(`Address ${this.toString()} does not contain subaddress: ${addr.toString()}`)
     }
-    return new Multiaddr(s.slice(0, i))
+    return new DefaultMultiaddr(s.slice(0, i))
   }
 
   /**
@@ -328,7 +650,7 @@ export class Multiaddr {
     const tuples = this.tuples()
     for (let i = tuples.length - 1; i >= 0; i--) {
       if (tuples[i][0] === code) {
-        return new Multiaddr(codec.tuplesToBytes(tuples.slice(0, i)))
+        return new DefaultMultiaddr(codec.tuplesToBytes(tuples.slice(0, i)))
       }
     }
     return this
@@ -459,7 +781,7 @@ export class Multiaddr {
     }
 
     const addresses = await resolver(this, options)
-    return addresses.map((a) => new Multiaddr(a))
+    return addresses.map((a) => new DefaultMultiaddr(a))
   }
 
   /**
@@ -533,55 +855,6 @@ export class Multiaddr {
   }
 
   /**
-   * Creates a Multiaddr from a node-friendly address object
-   *
-   * @example
-   * ```js
-   * Multiaddr.fromNodeAddress({address: '127.0.0.1', port: '4001'}, 'tcp')
-   * // <Multiaddr 047f000001060fa1 - /ip4/127.0.0.1/tcp/4001>
-   * ```
-   */
-  static fromNodeAddress (addr: NodeAddress, transport: string) {
-    if (addr == null) {
-      throw new Error('requires node address object')
-    }
-    if (transport == null) {
-      throw new Error('requires transport protocol')
-    }
-    let ip
-    switch (addr.family) {
-      case 4:
-        ip = 'ip4'
-        break
-      case 6:
-        ip = 'ip6'
-        break
-      default:
-        throw Error('Invalid addr family, should be 4 or 6.')
-    }
-    return new Multiaddr('/' + [ip, addr.address, transport, addr.port].join('/'))
-  }
-
-  /**
-   * Returns if something is a Multiaddr that is a name
-   */
-  static isName (addr: Multiaddr) {
-    if (!Multiaddr.isMultiaddr(addr)) {
-      return false
-    }
-
-    // if a part of the multiaddr is resolvable, then return true
-    return addr.protos().some((proto) => proto.resolvable)
-  }
-
-  /**
-   * Check if object is a CID instance
-   */
-  static isMultiaddr (value: any): value is Multiaddr {
-    return Boolean(value?.[symbol])
-  }
-
-  /**
    * Returns Multiaddr as a human-readable string.
    * For post Node.js v10.0.0.
    * https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect
@@ -619,9 +892,8 @@ export class Multiaddr {
 /**
  * Static factory
  */
-export function multiaddr (addr: MultiaddrInput) {
-  return new Multiaddr(addr)
+export function multiaddr (addr?: MultiaddrInput): Multiaddr {
+  return new DefaultMultiaddr(addr)
 }
 
 export { getProtocol as protocols }
-export { resolvers }

--- a/src/index.ts
+++ b/src/index.ts
@@ -866,9 +866,7 @@ class DefaultMultiaddr implements Multiaddr {
    * ```
    */
   [inspect] () {
-    return '<Multiaddr ' +
-    uint8ArrayToString(this.bytes, 'base16') + ' - ' +
-    codec.bytesToString(this.bytes) + '>'
+    return this.inspect()
   }
 
   /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,6 +1,7 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
-import { Multiaddr } from '../src/index.js'
+import { multiaddr, isMultiaddr, fromNodeAddress, isName } from '../src/index.js'
+import type { Multiaddr } from '../src/index.js'
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { codes } from '../src/protocols-table.js'
@@ -9,65 +10,65 @@ describe('construction', () => {
   let udpAddr: Multiaddr
 
   it('create multiaddr', () => {
-    udpAddr = new Multiaddr('/ip4/127.0.0.1/udp/1234')
-    expect(udpAddr instanceof Multiaddr).to.equal(true)
+    udpAddr = multiaddr('/ip4/127.0.0.1/udp/1234')
+    expect(isMultiaddr(udpAddr)).to.equal(true)
   })
 
   it('clone multiaddr', () => {
-    const udpAddrClone = new Multiaddr(udpAddr)
+    const udpAddrClone = multiaddr(udpAddr)
     expect(udpAddrClone !== udpAddr).to.equal(true)
   })
 
   it('reconstruct with buffer', () => {
-    expect(new Multiaddr(udpAddr.bytes).bytes === udpAddr.bytes).to.equal(false)
-    expect(new Multiaddr(udpAddr.bytes).bytes).to.deep.equal(udpAddr.bytes)
+    expect(multiaddr(udpAddr.bytes).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr.bytes).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with string', () => {
-    expect(new Multiaddr(udpAddr.toString()).bytes === udpAddr.bytes).to.equal(false)
-    expect(new Multiaddr(udpAddr.toString()).bytes).to.deep.equal(udpAddr.bytes)
+    expect(multiaddr(udpAddr.toString()).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr.toString()).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with object', () => {
-    expect(new Multiaddr(udpAddr).bytes === udpAddr.bytes).to.equal(false)
-    expect(new Multiaddr(udpAddr).bytes).to.deep.equal(udpAddr.bytes)
+    expect(multiaddr(udpAddr).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(udpAddr).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('reconstruct with JSON', () => {
-    expect(new Multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes === udpAddr.bytes).to.equal(false)
-    expect(new Multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes).to.deep.equal(udpAddr.bytes)
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes === udpAddr.bytes).to.equal(false)
+    expect(multiaddr(JSON.parse(JSON.stringify(udpAddr))).bytes).to.deep.equal(udpAddr.bytes)
   })
 
   it('empty construct still works', () => {
-    expect(new Multiaddr('').toString()).to.equal('/')
+    expect(multiaddr('').toString()).to.equal('/')
   })
 
   it('null/undefined construct still works', () => {
-    expect(new Multiaddr().toString()).to.equal('/')
-    expect(new Multiaddr(null).toString()).to.equal('/')
-    expect(new Multiaddr(undefined).toString()).to.equal('/')
+    expect(multiaddr().toString()).to.equal('/')
+    expect(multiaddr(null).toString()).to.equal('/')
+    expect(multiaddr(undefined).toString()).to.equal('/')
   })
 
   it('throws on truthy non string or buffer', () => {
     const errRegex = /addr must be a string/
     // @ts-expect-error
-    expect(() => new Multiaddr({})).to.throw(errRegex)
+    expect(() => multiaddr({})).to.throw(errRegex)
     // @ts-expect-error
-    expect(() => new Multiaddr([])).to.throw(errRegex)
+    expect(() => multiaddr([])).to.throw(errRegex)
     // @ts-expect-error
-    expect(() => new Multiaddr(138)).to.throw(errRegex)
+    expect(() => multiaddr(138)).to.throw(errRegex)
     // @ts-expect-error
-    expect(() => new Multiaddr(true)).to.throw(errRegex)
+    expect(() => multiaddr(true)).to.throw(errRegex)
   })
 
   it('throws on falsy non string or buffer', () => {
     const errRegex = /addr must be a string/
     // @ts-expect-error
-    expect(() => new Multiaddr(NaN)).to.throw(errRegex)
+    expect(() => multiaddr(NaN)).to.throw(errRegex)
     // @ts-expect-error
-    expect(() => new Multiaddr(false)).to.throw(errRegex)
+    expect(() => multiaddr(false)).to.throw(errRegex)
     // @ts-expect-error
-    expect(() => new Multiaddr(0)).to.throw(errRegex)
+    expect(() => multiaddr(0)).to.throw(errRegex)
   })
 })
 
@@ -75,32 +76,32 @@ describe('requiring varint', () => {
   let uTPAddr: Multiaddr
 
   it('create multiaddr', () => {
-    uTPAddr = new Multiaddr('/ip4/127.0.0.1/udp/1234/utp')
-    expect(uTPAddr instanceof Multiaddr).to.equal(true)
+    uTPAddr = multiaddr('/ip4/127.0.0.1/udp/1234/utp')
+    expect(isMultiaddr(uTPAddr)).to.equal(true)
   })
 
   it('clone multiaddr', () => {
-    const uTPAddrClone = new Multiaddr(uTPAddr)
+    const uTPAddrClone = multiaddr(uTPAddr)
     expect(uTPAddrClone !== uTPAddr).to.equal(true)
   })
 
   it('reconstruct with buffer', () => {
-    expect(new Multiaddr(uTPAddr.bytes).bytes === uTPAddr.bytes).to.equal(false)
-    expect(new Multiaddr(uTPAddr.bytes).bytes).to.deep.equal(uTPAddr.bytes)
+    expect(multiaddr(uTPAddr.bytes).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr.bytes).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('reconstruct with string', () => {
-    expect(new Multiaddr(uTPAddr.toString()).bytes === uTPAddr.bytes).to.equal(false)
-    expect(new Multiaddr(uTPAddr.toString()).bytes).to.deep.equal(uTPAddr.bytes)
+    expect(multiaddr(uTPAddr.toString()).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr.toString()).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('reconstruct with object', () => {
-    expect(new Multiaddr(uTPAddr).bytes === uTPAddr.bytes).to.equal(false)
-    expect(new Multiaddr(uTPAddr).bytes).to.deep.equal(uTPAddr.bytes)
+    expect(multiaddr(uTPAddr).bytes === uTPAddr.bytes).to.equal(false)
+    expect(multiaddr(uTPAddr).bytes).to.deep.equal(uTPAddr.bytes)
   })
 
   it('empty construct still works', () => {
-    expect(new Multiaddr('').toString()).to.equal('/')
+    expect(multiaddr('').toString()).to.equal('/')
   })
 })
 
@@ -108,7 +109,7 @@ describe('manipulation', () => {
   it('basic', () => {
     const udpAddrStr = '/ip4/127.0.0.1/udp/1234'
     const udpAddrBuf = uint8ArrayFromString('047f000001910204d2', 'base16')
-    const udpAddr = new Multiaddr(udpAddrStr)
+    const udpAddr = multiaddr(udpAddrStr)
 
     expect(udpAddr.toString()).to.equal(udpAddrStr)
     expect(udpAddr.bytes).to.deep.equal(udpAddrBuf)
@@ -123,18 +124,18 @@ describe('manipulation', () => {
     expect(udpAddrbytes2.decapsulate('/udp').toString()).to.equal('/ip4/127.0.0.1/udp/1234')
     expect(udpAddrbytes2.decapsulate('/ip4').toString()).to.equal('/')
     expect(function () { udpAddr.decapsulate('/').toString() }).to.throw()
-    expect(new Multiaddr('/').encapsulate(udpAddr).toString()).to.equal(udpAddr.toString())
-    expect(new Multiaddr('/').decapsulate('/').toString()).to.equal('/')
+    expect(multiaddr('/').encapsulate(udpAddr).toString()).to.equal(udpAddr.toString())
+    expect(multiaddr('/').decapsulate('/').toString()).to.equal('/')
   })
 
   it('ipfs', () => {
-    const ipfsAddr = new Multiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
-    const ip6Addr = new Multiaddr('/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095')
-    const tcpAddr = new Multiaddr('/tcp/8000')
-    const webAddr = new Multiaddr('/ws')
+    const ipfsAddr = multiaddr('/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+    const ip6Addr = multiaddr('/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095')
+    const tcpAddr = multiaddr('/tcp/8000')
+    const webAddr = multiaddr('/ws')
 
     expect(
-      new Multiaddr('/')
+      multiaddr('/')
         .encapsulate(ip6Addr)
         .encapsulate(tcpAddr)
         .encapsulate(webAddr)
@@ -148,7 +149,7 @@ describe('manipulation', () => {
     ].join(''))
 
     expect(
-      new Multiaddr('/')
+      multiaddr('/')
         .encapsulate(ip6Addr)
         .encapsulate(tcpAddr)
         .encapsulate(webAddr)
@@ -162,7 +163,7 @@ describe('manipulation', () => {
     ].join(''))
 
     expect(
-      new Multiaddr('/')
+      multiaddr('/')
         .encapsulate(ip6Addr)
         .encapsulate(tcpAddr)
         .encapsulate(ipfsAddr)
@@ -180,63 +181,63 @@ describe('manipulation', () => {
 describe('variants', () => {
   it('ip4', () => {
     const str = '/ip4/127.0.0.1'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp', () => {
     const str = '/ip4/127.0.0.1/tcp/5000'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/5000'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + udp', () => {
     const str = '/ip4/127.0.0.1/udp/5000'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/5000'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + p2p', () => {
     const str = '/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + ipfs', () => {
     const str = '/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
@@ -249,14 +250,14 @@ describe('variants', () => {
 
   it('ip4 + udp + utp', () => {
     const str = '/ip4/127.0.0.1/udp/5000/utp'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp + utp', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/5000/utp'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.protoNames())
     expect(addr.toString()).to.equal(str)
@@ -264,226 +265,226 @@ describe('variants', () => {
 
   it('ip4 + tcp + http', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/http'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + unix', () => {
     const str = '/ip4/127.0.0.1/tcp/80/unix/a/b/c/d/e/f'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + http', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/http'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + unix', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/unix/a/b/c/d/e/f'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + https', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/https'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + https', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/https'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 + tcp + websockets', () => {
     const str = '/ip4/127.0.0.1/tcp/8000/ws'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + tcp + websockets + ipfs', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + tcp + websockets + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip6 + udp + quic + ipfs', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('ip6 + udp + quic + p2p', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('webtransport', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/webtransport'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('ip4 webtransport', () => {
     const str = '/ip4/1.2.3.4/udp/4001/quic/webtransport'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('unix', () => {
     const str = '/unix/a/b/c/d/e'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p', () => {
     const str = '/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal('/p2p/QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')
   })
 
   it('ipfs', () => {
     const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('onion', () => {
     const str = '/onion/timaq4ygg2iegci7:1234'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('onion bad length', () => {
     const str = '/onion/timaq4ygg2iegci:80'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('onion bad port', () => {
     const str = '/onion/timaq4ygg2iegci7:-1'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('onion no port', () => {
     const str = '/onion/timaq4ygg2iegci7'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('onion3', () => {
     const str = '/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:1234'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('onion3 bad length', () => {
     const str = '/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopyyd:1234'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('onion3 bad port', () => {
     const str = '/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd:-1'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('onion3 no port', () => {
     const str = '/onion3/vww6ybal4bd7szmgncyruucpgfkqahzddi37ktceo3ah7ngmcopnpyyd'
-    expect(() => new Multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw()
   })
 
   it('p2p-circuit', () => {
     const str = '/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-circuit p2p', () => {
     const str = '/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-circuit ipfs', () => {
     const str = '/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('p2p-webrtc-star', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-webrtc-star ipfs', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-webrtc-star/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
   it('p2p-webrtc-direct', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/http/p2p-webrtc-direct'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('p2p-websocket-star', () => {
     const str = '/ip4/127.0.0.1/tcp/9090/ws/p2p-websocket-star'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
 
   it('memory + p2p', () => {
     const str = '/memory/test/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC'
-    const addr = new Multiaddr(str)
+    const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)
   })
@@ -492,7 +493,7 @@ describe('variants', () => {
 describe('helpers', () => {
   describe('.toOptions', () => {
     it('returns a well formed options object', () => {
-      expect(new Multiaddr('/ip4/0.0.0.0/tcp/1234').toOptions())
+      expect(multiaddr('/ip4/0.0.0.0/tcp/1234').toOptions())
         .to.eql({
           family: 4,
           host: '0.0.0.0',
@@ -502,7 +503,7 @@ describe('helpers', () => {
     })
 
     it('returns an options object from a DNS addr', () => {
-      expect(new Multiaddr('/dns4/google.net/tcp/8000').toOptions())
+      expect(multiaddr('/dns4/google.net/tcp/8000').toOptions())
         .to.eql({
           family: 4,
           host: 'google.net',
@@ -512,7 +513,7 @@ describe('helpers', () => {
     })
 
     it('returns an options object from a DNS6 addr', () => {
-      expect(new Multiaddr('/dns6/google.net/tcp/8000').toOptions())
+      expect(multiaddr('/dns6/google.net/tcp/8000').toOptions())
         .to.eql({
           family: 6,
           host: 'google.net',
@@ -522,7 +523,7 @@ describe('helpers', () => {
     })
 
     it('returns an options object from a DNS addr defaulting to https', () => {
-      expect(new Multiaddr('/dnsaddr/google.net').toOptions())
+      expect(multiaddr('/dnsaddr/google.net').toOptions())
         .to.eql({
           family: 4,
           host: 'google.net',
@@ -532,7 +533,7 @@ describe('helpers', () => {
     })
 
     it('returns an options object from a DNS addr with a PeerID defaulting to https', () => {
-      expect(new Multiaddr('/dnsaddr/google.net/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').toOptions())
+      expect(multiaddr('/dnsaddr/google.net/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').toOptions())
         .to.eql({
           family: 4,
           host: 'google.net',
@@ -544,14 +545,14 @@ describe('helpers', () => {
 
   describe('.inspect', () => {
     it('renders the buffer as hex', () => {
-      expect(new Multiaddr('/ip4/0.0.0.0/tcp/1234').inspect())
+      expect(multiaddr('/ip4/0.0.0.0/tcp/1234').inspect())
         .to.eql('<Multiaddr 04000000000604d2 - /ip4/0.0.0.0/tcp/1234>')
     })
   })
 
   describe('.protos', () => {
     it('returns a list of all protocols in the address', () => {
-      expect(new Multiaddr('/ip4/0.0.0.0/utp').protos())
+      expect(multiaddr('/ip4/0.0.0.0/utp').protos())
         .to.eql([{
           code: 4,
           name: 'ip4',
@@ -569,7 +570,7 @@ describe('helpers', () => {
 
     it('works with ipfs', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/utp/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
+        multiaddr('/ip4/0.0.0.0/utp/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
       ).to.be.eql([{
         code: 4,
         name: 'ip4',
@@ -593,7 +594,7 @@ describe('helpers', () => {
 
     it('works with p2p', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/utp/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
+        multiaddr('/ip4/0.0.0.0/utp/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').protos()
       ).to.be.eql([{
         code: 4,
         name: 'ip4',
@@ -617,7 +618,7 @@ describe('helpers', () => {
 
     it('works with unix', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/8000/unix/tmp/p2p.sock').protos()
+        multiaddr('/ip4/0.0.0.0/tcp/8000/unix/tmp/p2p.sock').protos()
       ).to.be.eql([{
         code: 4,
         name: 'ip4',
@@ -641,7 +642,7 @@ describe('helpers', () => {
 
     it('works with memory', () => {
       expect(
-        new Multiaddr('/memory/test/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6').protos()
+        multiaddr('/memory/test/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6').protos()
       ).to.be.eql([{
         code: 777,
         name: 'memory',
@@ -660,7 +661,7 @@ describe('helpers', () => {
 
   describe('.tuples', () => {
     it('returns the tuples', () => {
-      expect(new Multiaddr('/ip4/0.0.0.0/utp').tuples())
+      expect(multiaddr('/ip4/0.0.0.0/utp').tuples())
         .to.eql([
           [4, Uint8Array.from([0, 0, 0, 0])],
           [302]
@@ -670,7 +671,7 @@ describe('helpers', () => {
 
   describe('.stringTuples', () => {
     it('returns the string partss', () => {
-      expect(new Multiaddr('/ip4/0.0.0.0/utp').stringTuples())
+      expect(multiaddr('/ip4/0.0.0.0/utp').stringTuples())
         .to.eql([
           [4, '0.0.0.0'],
           [302]
@@ -681,7 +682,7 @@ describe('helpers', () => {
   describe('.decapsulate', () => {
     it('throws on address with no matching subaddress', () => {
       expect(
-        () => new Multiaddr('/ip4/127.0.0.1').decapsulate('/ip4/198.168.0.0')
+        () => multiaddr('/ip4/127.0.0.1').decapsulate('/ip4/198.168.0.0')
       ).to.throw(
         /does not contain subaddress/
       )
@@ -690,31 +691,31 @@ describe('helpers', () => {
 
   describe('.decapsulateCode', () => {
     it('removes the last occurrence of the code from the multiaddr', () => {
-      const relayTCP = new Multiaddr('/ip4/0.0.0.0/tcp/8080')
+      const relayTCP = multiaddr('/ip4/0.0.0.0/tcp/8080')
       const relay = relayTCP.encapsulate('/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit')
-      const target = new Multiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
+      const target = multiaddr('/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
       const original = relay.encapsulate(target)
       expect(original.decapsulateCode(421)).to.eql(relay)
       expect(relay.decapsulateCode(421)).to.eql(relayTCP)
     })
 
     it('ignores missing codes', () => {
-      const tcp = new Multiaddr('/ip4/0.0.0.0/tcp/8080')
+      const tcp = multiaddr('/ip4/0.0.0.0/tcp/8080')
       expect(tcp.decapsulateCode(421)).to.eql(tcp)
     })
   })
 
   describe('.equals', () => {
     it('returns true for equal addresses', () => {
-      const addr1 = new Multiaddr('/ip4/192.168.0.1')
-      const addr2 = new Multiaddr('/ip4/192.168.0.1')
+      const addr1 = multiaddr('/ip4/192.168.0.1')
+      const addr2 = multiaddr('/ip4/192.168.0.1')
 
       expect(addr1.equals(addr2)).to.equal(true)
     })
 
     it('returns false for non equal addresses', () => {
-      const addr1 = new Multiaddr('/ip4/192.168.1.1')
-      const addr2 = new Multiaddr('/ip4/192.168.0.1')
+      const addr1 = multiaddr('/ip4/192.168.1.1')
+      const addr2 = multiaddr('/ip4/192.168.0.1')
 
       expect(addr1.equals(addr2)).to.equal(false)
     })
@@ -723,7 +724,7 @@ describe('helpers', () => {
   describe('.nodeAddress', () => {
     it('throws on an invalid node address', () => {
       expect(
-        () => new Multiaddr('/ip4/192.168.0.1/utp').nodeAddress()
+        () => multiaddr('/ip4/192.168.0.1/utp').nodeAddress()
       ).to.throw(
         /multiaddr must have a valid format/
       )
@@ -731,7 +732,7 @@ describe('helpers', () => {
 
     it('returns a node friendly address', () => {
       expect(
-        new Multiaddr('/ip4/192.168.0.1/tcp/1234').nodeAddress()
+        multiaddr('/ip4/192.168.0.1/tcp/1234').nodeAddress()
       ).to.be.eql({
         address: '192.168.0.1',
         family: 4,
@@ -741,7 +742,7 @@ describe('helpers', () => {
 
     it('returns a node friendly address with dns', () => {
       expect(
-        new Multiaddr('/dns/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
+        multiaddr('/dns/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
       ).to.be.eql({
         address: 'wss0.bootstrap.libp2p.io',
         family: 4,
@@ -751,7 +752,7 @@ describe('helpers', () => {
 
     it('returns a node friendly address with dns4', () => {
       expect(
-        new Multiaddr('/dns4/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
+        multiaddr('/dns4/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
       ).to.be.eql({
         address: 'wss0.bootstrap.libp2p.io',
         family: 4,
@@ -761,7 +762,7 @@ describe('helpers', () => {
 
     it('returns a node friendly address with dns6', () => {
       expect(
-        new Multiaddr('/dns6/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
+        multiaddr('/dns6/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
       ).to.be.eql({
         address: 'wss0.bootstrap.libp2p.io',
         family: 6,
@@ -771,7 +772,7 @@ describe('helpers', () => {
 
     it('returns a node friendly address with dnsaddr', () => {
       expect(
-        new Multiaddr('/dnsaddr/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
+        multiaddr('/dnsaddr/wss0.bootstrap.libp2p.io/tcp/443').nodeAddress()
       ).to.be.eql({
         address: 'wss0.bootstrap.libp2p.io',
         family: 4,
@@ -781,7 +782,7 @@ describe('helpers', () => {
 
     it('should transform a p2p dnsaddr without a tcp port into a node address', () => {
       expect(
-        new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN').nodeAddress()
+        multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN').nodeAddress()
       ).to.be.eql({
         address: 'bootstrap.libp2p.io',
         family: 4,
@@ -791,7 +792,7 @@ describe('helpers', () => {
 
     it('throws on an invalid format address when the addr is not prefixed with a /', () => {
       expect(
-        () => new Multiaddr('ip4/192.168.0.1/udp').nodeAddress()
+        () => multiaddr('ip4/192.168.0.1/udp').nodeAddress()
       ).to.throw(
         /must start with a/
       )
@@ -799,7 +800,7 @@ describe('helpers', () => {
 
     it('throws on an invalid protocol name when the addr has an invalid one', () => {
       expect(
-        () => new Multiaddr('/ip5/127.0.0.1/udp/5000')
+        () => multiaddr('/ip5/127.0.0.1/udp/5000')
       ).to.throw(
         /no protocol with name/
       )
@@ -807,7 +808,7 @@ describe('helpers', () => {
 
     it('throws on an invalid protocol name when the transport protocol is not valid', () => {
       expect(
-        () => new Multiaddr('/ip4/127.0.0.1/utp/5000')
+        () => multiaddr('/ip4/127.0.0.1/utp/5000')
       ).to.throw(
         /no protocol with name/
       )
@@ -818,7 +819,7 @@ describe('helpers', () => {
     it('throws on missing address object', () => {
       expect(
         // @ts-expect-error
-        () => Multiaddr.fromNodeAddress()
+        () => fromNodeAddress()
       ).to.throw(
         /requires node address/
       )
@@ -827,7 +828,7 @@ describe('helpers', () => {
     it('throws on missing transport', () => {
       expect(
         // @ts-expect-error
-        () => Multiaddr.fromNodeAddress({ address: '0.0.0.0' })
+        () => fromNodeAddress({ address: '0.0.0.0' })
       ).to.throw(
         /requires transport protocol/
       )
@@ -835,7 +836,7 @@ describe('helpers', () => {
 
     it('parses a node address', () => {
       expect(
-        Multiaddr.fromNodeAddress({
+        fromNodeAddress({
           address: '192.168.0.1',
           family: 4,
           port: 1234
@@ -857,7 +858,7 @@ describe('helpers', () => {
       transports.forEach((transport) => {
         it(`returns true for /${family}-${transport}`, () => {
           expect(
-            new Multiaddr(`/${family}/${addresses[family]}/${transport}/1234`).isThinWaistAddress()
+            multiaddr(`/${family}/${addresses[family]}/${transport}/1234`).isThinWaistAddress()
           ).to.equal(true)
         })
       })
@@ -865,17 +866,17 @@ describe('helpers', () => {
 
     it('returns false for two protocols not using {IPv4, IPv6}/{TCP, UDP}', () => {
       expect(
-        new Multiaddr('/ip4/192.168.0.1/utp').isThinWaistAddress()
+        multiaddr('/ip4/192.168.0.1/utp').isThinWaistAddress()
       ).to.equal(false)
 
       expect(
-        new Multiaddr('/sctp/192.168.0.1/tcp/1234').isThinWaistAddress()
+        multiaddr('/sctp/192.168.0.1/tcp/1234').isThinWaistAddress()
       ).to.eql(
         false
       )
 
       expect(
-        new Multiaddr('/http/utp').isThinWaistAddress()
+        multiaddr('/http/utp').isThinWaistAddress()
       ).to.eql(
         false
       )
@@ -883,7 +884,7 @@ describe('helpers', () => {
 
     it('returns false for more than two protocols', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/1234/utp').isThinWaistAddress()
+        multiaddr('/ip4/0.0.0.0/tcp/1234/utp').isThinWaistAddress()
       ).to.equal(
         false
       )
@@ -893,32 +894,32 @@ describe('helpers', () => {
   describe('.getPeerId should parse id from multiaddr', () => {
     it('extracts the peer Id from a multiaddr, p2p', () => {
       expect(
-        new Multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+        multiaddr('/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
     it('extracts the correct peer Id from a circuit multiaddr', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+        multiaddr('/ip4/0.0.0.0/tcp/8080/p2p/QmZR5a9AAXGqQF2ADqoDdGS8zvqv8n3Pag6TDDnTNMcFW6/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
     it('extracts the peer Id from a multiaddr, ipfs', () => {
       expect(
-        new Multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
+        multiaddr('/p2p-circuit/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPeerId()
       ).to.equal('QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC')
     })
     it('extracts the peer Id from a multiaddr, p2p and CIDv1 Base32', () => {
       expect(
-        new Multiaddr('/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4').getPeerId()
+        multiaddr('/p2p-circuit/p2p/bafzbeigweq4zr4x4ky2dvv7nanbkw6egutvrrvzw6g3h2rftp7gidyhtt4').getPeerId()
       ).to.equal('QmckZzdVd72h9QUFuJJpQqhsZqGLwjhh81qSvZ9BhB2FQi')
     })
     it('extracts the peer Id from a multiaddr, p2p and CIDv1 Base32, where Id contains non b58 chars', () => {
       expect(
-        new Multiaddr('/p2p-circuit/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4').getPeerId()
+        multiaddr('/p2p-circuit/p2p/bafzbeidt255unskpefjmqb2rc27vjuyxopkxgaylxij6pw35hhys4vnyp4').getPeerId()
       ).to.equal('QmW8rAgaaA6sRydK1k6vonShQME47aDxaFidbtMevWs73t')
     })
     it('extracts the peer Id from a multiaddr, p2p and base58btc encoded identity multihash', () => {
       expect(
-        new Multiaddr('/p2p-circuit/p2p/12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p').getPeerId()
+        multiaddr('/p2p-circuit/p2p/12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p').getPeerId()
       ).to.equal('12D3KooWNvSZnPi3RrhrTwEY4LuuBeB6K6facKUCJcyWG1aoDd2p')
     })
   })
@@ -926,7 +927,7 @@ describe('helpers', () => {
   describe('.getPeerId should return null on missing peer id in multiaddr', () => {
     it('parses extracts the peer Id from a multiaddr', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/1234/utp').getPeerId()
+        multiaddr('/ip4/0.0.0.0/tcp/1234/utp').getPeerId()
       ).to.be.null()
     })
   })
@@ -934,30 +935,30 @@ describe('helpers', () => {
   describe('.getPath', () => {
     it('should return a path for unix', () => {
       expect(
-        new Multiaddr('/unix/tmp/p2p.sock').getPath()
+        multiaddr('/unix/tmp/p2p.sock').getPath()
       ).to.eql('/tmp/p2p.sock')
     })
 
     it('should return a path for unix when other protos exist', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/1234/unix/tmp/p2p.sock').getPath()
+        multiaddr('/ip4/0.0.0.0/tcp/1234/unix/tmp/p2p.sock').getPath()
       ).to.eql('/tmp/p2p.sock')
     })
 
     it('should not return a path when no path proto exists', () => {
       expect(
-        new Multiaddr('/ip4/0.0.0.0/tcp/1234/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPath()
+        multiaddr('/ip4/0.0.0.0/tcp/1234/p2p-circuit/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC').getPath()
       ).to.eql(null)
     })
   })
 
   describe('multiaddr.isMultiaddr', () => {
     it('handles different inputs', () => {
-      expect(Multiaddr.isMultiaddr(new Multiaddr('/'))).to.be.eql(true)
-      expect(Multiaddr.isMultiaddr('/')).to.be.eql(false)
-      expect(Multiaddr.isMultiaddr(123)).to.be.eql(false)
+      expect(isMultiaddr(multiaddr('/'))).to.be.eql(true)
+      expect(isMultiaddr('/')).to.be.eql(false)
+      expect(isMultiaddr(123)).to.be.eql(false)
 
-      expect(Multiaddr.isMultiaddr(uint8ArrayFromString('/hello'))).to.be.eql(false)
+      expect(isMultiaddr(uint8ArrayFromString('/hello'))).to.be.eql(false)
     })
   })
 
@@ -965,32 +966,32 @@ describe('helpers', () => {
     describe('.isName', () => {
       it('valid name dns', () => {
         const str = '/dns/ipfs.io'
-        const addr = new Multiaddr(str)
-        expect(Multiaddr.isName(addr)).to.equal(true)
+        const addr = multiaddr(str)
+        expect(isName(addr)).to.equal(true)
       })
 
       it('valid name dnsaddr', () => {
         const str = '/dnsaddr/ipfs.io'
-        const addr = new Multiaddr(str)
-        expect(Multiaddr.isName(addr)).to.equal(true)
+        const addr = multiaddr(str)
+        expect(isName(addr)).to.equal(true)
       })
 
       it('valid name dns4', () => {
         const str = '/dns4/ipfs.io'
-        const addr = new Multiaddr(str)
-        expect(Multiaddr.isName(addr)).to.equal(true)
+        const addr = multiaddr(str)
+        expect(isName(addr)).to.equal(true)
       })
 
       it('valid name dns6', () => {
         const str = '/dns6/ipfs.io'
-        const addr = new Multiaddr(str)
-        expect(Multiaddr.isName(addr)).to.equal(true)
+        const addr = multiaddr(str)
+        expect(isName(addr)).to.equal(true)
       })
 
       it('invalid name', () => {
         const str = '/ip4/127.0.0.1'
-        const addr = new Multiaddr(str)
-        expect(Multiaddr.isName(addr)).to.equal(false)
+        const addr = multiaddr(str)
+        expect(isName(addr)).to.equal(false)
       })
     })
   })

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
-import { Multiaddr } from '../src/index.js'
-import * as resolvers from '../src/resolvers/index.js'
+import { multiaddr, resolvers } from '../src/index.js'
+import * as resolversInternal from '../src/resolvers/index.js'
 import Resolver from '../src/resolvers/dns.js'
 
 const dnsaddrStub1 = [
@@ -25,7 +25,7 @@ const dnsaddrStub2 = [
 
 describe('multiaddr resolve', () => {
   it('should throw if no resolver is available', async () => {
-    const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.io')
+    const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
 
     // Resolve
     await expect(ma.resolve()).to.eventually.be.rejected()
@@ -35,7 +35,7 @@ describe('multiaddr resolve', () => {
   describe('dnsaddr', () => {
     before(() => {
       // Set resolvers
-      Multiaddr.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+      resolvers.set('dnsaddr', resolversInternal.dnsaddrResolver)
     })
 
     afterEach(() => {
@@ -43,7 +43,7 @@ describe('multiaddr resolve', () => {
     })
 
     it('can resolve dnsaddr without no peerId', async () => {
-      const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.io')
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
 
       const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
@@ -55,12 +55,12 @@ describe('multiaddr resolve', () => {
       resolvedMas.forEach((ma, index) => {
         const stubAddr = dnsaddrStub1[index][0].split('=')[1]
 
-        expect(ma.equals(new Multiaddr(stubAddr))).to.equal(true)
+        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
       })
     })
 
     it('can resolve dnsaddr with peerId', async () => {
-      const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
 
       const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
@@ -70,11 +70,11 @@ describe('multiaddr resolve', () => {
       const resolvedMas = await ma.resolve()
 
       expect(resolvedMas).to.have.length(1)
-      expect(resolvedMas[0].equals(new Multiaddr('/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'))).to.eql(true)
+      expect(resolvedMas[0].equals(multiaddr('/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'))).to.eql(true)
     })
 
     it('can resolve dnsaddr with peerId two levels', async () => {
-      const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
 
       const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
       stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
@@ -94,12 +94,12 @@ describe('multiaddr resolve', () => {
       resolvedMas.forEach((ma, index) => {
         const stubAddr = dnsaddrStub2[index][0].split('=')[1]
 
-        expect(ma.equals(new Multiaddr(stubAddr))).to.equal(true)
+        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
       })
     })
 
     it('can cancel resolving', async () => {
-      const ma = new Multiaddr('/dnsaddr/bootstrap.libp2p.ii/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nc')
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.ii/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nc')
       const controller = new AbortController()
 
       // Resolve


### PR DESCRIPTION
- Renames the `Multiaddr` class to `DefaultMultiaddr`
- Exports `Multiaddr` as an interface

The `multiaddr` function (introduced in v9.0.0) should be used to create new instances of `Multiaddr` instead of instantiating the `Multiaddr` class directly.

This allows us to remove the `inspect` symbol from the interface and avoid use of `Object.defineProperty` which is very slow:

<img width="507" alt="image" src="https://user-images.githubusercontent.com/665810/191237265-2f2d1bf4-6325-4189-9847-2239099185e8.png">

Fixes: #202

BREAKING CHANGE: the `Multiaddr` class is now an interface