### PR TITLE
fix: cache string and tuple represntations

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -4,6 +4,7 @@ import varint from 'varint'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import type { Protocol } from './protocols-table.js'
+import type { StringTuple, Tuple } from './index.js'
 
 /**
  * string -> [[str name, str addr]... ]
@@ -50,7 +51,7 @@ export function stringToStringTuples (str: string) {
 /**
  * [[str name, str addr]... ] -> string
  */
-export function stringTuplesToString (tuples: Array<[number, string?]>) {
+export function stringTuplesToString (tuples: StringTuple[]) {
   const parts: string[] = []
   tuples.map((tup) => {
     const proto = protoFromTuple(tup)
@@ -67,7 +68,7 @@ export function stringTuplesToString (tuples: Array<[number, string?]>) {
 /**
  * [[str name, str addr]... ] -> [[int code, Uint8Array]... ]
  */
-export function stringTuplesToTuples (tuples: Array<string[] | string>): Array<[number, Uint8Array?]> {
+export function stringTuplesToTuples (tuples: Array<string[] | string>): Tuple[] {
   return tuples.map((tup) => {
     if (!Array.isArray(tup)) {
       tup = [tup]
@@ -85,7 +86,7 @@ export function stringTuplesToTuples (tuples: Array<string[] | string>): Array<[
  *
  * [[int code, Uint8Array]... ] -> [[int code, str addr]... ]
  */
-export function tuplesToStringTuples (tuples: Array<[number, Uint8Array?]>): Array<[number, string?]> {
+export function tuplesToStringTuples (tuples: Tuple[]): StringTuple[] {
   return tuples.map(tup => {
     const proto = protoFromTuple(tup)
     if (tup[1] != null) {
@@ -98,7 +99,7 @@ export function tuplesToStringTuples (tuples: Array<[number, Uint8Array?]>): Arr
 /**
  * [[int code, Uint8Array ]... ] -> Uint8Array
  */
-export function tuplesToBytes (tuples: Array<[number, Uint8Array?]>) {
+export function tuplesToBytes (tuples: Tuple[]) {
   return fromBytes(uint8ArrayConcat(tuples.map((tup) => {
     const proto = protoFromTuple(tup)
     let buf = Uint8Array.from(varint.encode(proto.code))
@@ -122,7 +123,7 @@ export function sizeForAddr (p: Protocol, addr: Uint8Array | number[]) {
   }
 }
 
-export function bytesToTuples (buf: Uint8Array): Array<[number, Uint8Array?]> {
+export function bytesToTuples (buf: Uint8Array): Tuple[] {
   const tuples: Array<[number, Uint8Array?]> = []
   let i = 0
   while (i < buf.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ export type MultiaddrInput = string | Multiaddr | Uint8Array | null
 
 export interface Resolver { (addr: Multiaddr, options?: AbortOptions): Promise<string[]> }
 
+export type Tuple = [number, Uint8Array?]
+
+export type StringTuple = [number, string?]
+
 export interface AbortOptions {
   signal?: AbortSignal
 }
@@ -137,7 +141,7 @@ export interface Multiaddr {
    * // [ [ 4, <Buffer 7f 00 00 01> ], [ 6, <Buffer 0f a1> ] ]
    * ```
    */
-  tuples: () => Array<[number, Uint8Array?]>
+  tuples: () => Tuple[]
 
   /**
    * Returns a tuple of string/number parts
@@ -150,7 +154,7 @@ export interface Multiaddr {
    * // [ [ 4, '127.0.0.1' ], [ 6, '4001' ] ]
    * ```
    */
-  stringTuples: () => Array<[number, string?]>
+  stringTuples: () => StringTuple[]
 
   /**
    * Encapsulates a Multiaddr in another Multiaddr
@@ -396,6 +400,8 @@ export function isMultiaddr (value: any): value is Multiaddr {
  */
 class DefaultMultiaddr implements Multiaddr {
   public bytes: Uint8Array
+  private _string?: string
+  private _tuples?: Tuple[]
 
   [symbol]: boolean = true
 
@@ -429,7 +435,11 @@ class DefaultMultiaddr implements Multiaddr {
   }
 
   toString () {
-    return codec.bytesToString(this.bytes)
+    if (this._string == null) {
+      this._string = codec.bytesToString(this.bytes)
+    }
+
+    return this._string
   }
 
   toJSON () {
@@ -495,11 +505,15 @@ class DefaultMultiaddr implements Multiaddr {
   }
 
   tuples (): Array<[number, Uint8Array?]> {
-    return codec.bytesToTuples(this.bytes)
+    if (this._tuples == null) {
+      this._tuples = codec.bytesToTuples(this.bytes)
+    }
+
+    return this._tuples
   }
 
   stringTuples (): Array<[number, string?]> {
-    const t = codec.bytesToTuples(this.bytes)
+    const t = this.tuples()
     return codec.tuplesToStringTuples(t)
   }
 


### PR DESCRIPTION
Converting multiaddrs to strings and tuples is expensive and done in many places so cache these representations when they are first requested.