### PR TITLE
test: webtransport with certhash

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -347,7 +347,7 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str)
   })
 
-  it('webtransport', () => {
+  it('ip6 webtransport', () => {
     const str = '/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/udp/4001/quic/webtransport'
     const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
@@ -356,6 +356,13 @@ describe('variants', () => {
 
   it('ip4 webtransport', () => {
     const str = '/ip4/1.2.3.4/udp/4001/quic/webtransport'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('bytes')
+    expect(addr.toString()).to.equal(str)
+  })
+
+  it('webtransport with certhash', () => {
+    const str = '/ip4/1.2.3.4/udp/4001/quic/webtransport/certhash/uEiAkH5a4DPGKUuOBjYw0CgwjvcJCJMD2K_1aluKR_tpevQ/certhash/uEiAfbgiymPP2_nX7Dgir8B4QkksjHp2lVuJZz0F79Be9JA/p2p/12D3KooWBdmLJjhpgJ9KZgLM3f894ff9xyBfPvPjFNn7MKJpyrC2'
     const addr = multiaddr(str)
     expect(addr).to.have.property('bytes')
     expect(addr.toString()).to.equal(str)


### PR DESCRIPTION
This PR adds tests for real-world  example of webtransport addr announced by Kubo 0.16.0-rc1 (with two certhashes).