### PR TITLE
chore: use @chainsafe/is-ip

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,9 +164,9 @@
     "release": "aegir release"
   },
   "dependencies": {
+    "@chainsafe/is-ip": "^1.0.0",
     "dns-over-http-resolver": "^2.1.0",
     "err-code": "^3.0.1",
-    "is-ip": "^5.0.0",
     "multiformats": "^10.0.0",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0"

--- a/src/ip.ts
+++ b/src/ip.ts
@@ -1,7 +1,7 @@
-import { isIPv4, isIPv6 } from 'is-ip'
+import { isIPv4, isIPv6 } from '@chainsafe/is-ip'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 
-export { isIP } from 'is-ip'
+export { isIP } from '@chainsafe/is-ip'
 export const isV4 = isIPv4
 export const isV6 = isIPv6
 


### PR DESCRIPTION
Problem:
`is-ip` 5.0.0 is significantly slower than 4.0.0. This is due to adding protection against regex DoS. It does so by wrapping its regex calls in [`node:vm` apis](https://nodejs.org/dist/latest-v16.x/docs/api/vm.html) with a timeout. Although the resulting code is protected against regex DoS, its also ~6000x slower, so slow that it shows up with non-negligible time in Lodestar cpu profiles.

Solution:
Replace `is-ip` dependency with `@chainsafe/is-ip`.
`@chainsafe/is-ip` is a drop-in replacement for `is-ip` that is a transliteration of some of rust's std net code. It's ~300x faster for valid IPv4 values, ~30x faster for valid IPv6 values than `is-ip` 5.0.0.

See discussion:
- https://github.com/ChainSafe/lodestar/issues/4689
- https://github.com/multiformats/js-multiaddr/pull/260

