### PR TITLE
deps: update @chainsafe/is-ip

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "release": "aegir release"
   },
   "dependencies": {
-    "@chainsafe/is-ip": "^1.0.0",
+    "@chainsafe/is-ip": "^2.0.1",
     "dns-over-http-resolver": "^2.1.0",
     "err-code": "^3.0.1",
     "multiformats": "^10.0.0",


### PR DESCRIPTION
See https://github.com/ChainSafe/is-ip/pull/1#issuecomment-1295761316
New version of `@chainsafe/is-ip` provides a node-specific export and faster base implementation.
This library unaffected by the breaking change