### PR TITLE
fix: varint.decode.bytes can now be undefined according to types

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -119,7 +119,7 @@ export function sizeForAddr (p: Protocol, addr: Uint8Array | number[]) {
     return 0
   } else {
     const size = varint.decode(addr)
-    return size + varint.decode.bytes
+    return size + (varint.decode.bytes ?? 0)
   }
 }
 
@@ -128,7 +128,7 @@ export function bytesToTuples (buf: Uint8Array): Tuple[] {
   let i = 0
   while (i < buf.length) {
     const code = varint.decode(buf, i)
-    const n = varint.decode.bytes
+    const n = varint.decode.bytes ?? 0
 
     const p = getProtocol(code)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -489,7 +489,7 @@ class DefaultMultiaddr implements Multiaddr {
     let i = 0
     while (i < buf.length) {
       const code = varint.decode(buf, i)
-      const n = varint.decode.bytes
+      const n = varint.decode.bytes ?? 0
 
       const p = getProtocol(code)
       const size = codec.sizeForAddr(p, buf.slice(i + n))


### PR DESCRIPTION
The types for varint were updated, now the `.bytes` property on `varint.decode` can be undefined.