### PR TITLE
feat: add TLS to protocols-table

### DIFF
--- a/src/protocols-table.ts
+++ b/src/protocols-table.ts
@@ -35,6 +35,7 @@ export const table: Array<[number, number, string, boolean?, boolean?]> = [
   [444, 96, 'onion'],
   [445, 296, 'onion3'],
   [446, V, 'garlic64'],
+  [448, 0, 'tls'],
   [460, 0, 'quic'],
   [461, 0, 'quic-v1'],
   [465, 0, 'webtransport'],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -424,6 +424,13 @@ describe('variants', () => {
     expect(addr.toString()).to.equal(str.replace('/ipfs/', '/p2p/'))
   })
 
+  it('tls', () => {
+    const str = '/ip4/127.0.0.1/tcp/9090/tls/ws'
+    const addr = multiaddr(str)
+    expect(addr).to.have.property('bytes')
+    expect(addr.toString()).to.equal(str)
+  })
+
   it('onion', () => {
     const str = '/onion/timaq4ygg2iegci7:1234'
     const addr = multiaddr(str)
@@ -1056,5 +1063,12 @@ describe('helpers', () => {
         expect(isName(addr)).to.equal(false)
       })
     })
+  })
+})
+
+describe("unknown protocols", () => {
+  it("throws an error", () => {
+    const str = '/ip4/127.0.0.1/unknown'
+    expect(() => multiaddr(str)).to.throw()
   })
 })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1066,8 +1066,8 @@ describe('helpers', () => {
   })
 })
 
-describe("unknown protocols", () => {
-  it("throws an error", () => {
+describe('unknown protocols', () => {
+  it('throws an error', () => {
     const str = '/ip4/127.0.0.1/unknown'
     expect(() => multiaddr(str)).to.throw()
   })

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1069,6 +1069,6 @@ describe('helpers', () => {
 describe('unknown protocols', () => {
   it('throws an error', () => {
     const str = '/ip4/127.0.0.1/unknown'
-    expect(() => multiaddr(str)).to.throw()
+    expect(() => multiaddr(str)).to.throw('no protocol with name: unknown')
   })
 })


### PR DESCRIPTION
This allows the construction of `/tls/ws` which is identical and preferred to `/wss`. Similar with `/http`