### PR TITLE
feat: Add webrtc-w3c protocol for browser to browser

### DIFF
--- a/src/protocols-table.ts
+++ b/src/protocols-table.ts
@@ -21,7 +21,7 @@ export const table: Array<[number, number, string, boolean?, boolean?]> = [
   [276, 0, 'p2p-webrtc-direct'],
   [277, 0, 'p2p-stardust'],
   [280, 0, 'webrtc'],
-  [281, 0, 'webrtc-direct'],
+  [281, 0, 'webrtc-w3c'],
   [290, 0, 'p2p-circuit'],
   [301, 0, 'udt'],
   [302, 0, 'utp'],

--- a/src/protocols-table.ts
+++ b/src/protocols-table.ts
@@ -21,6 +21,7 @@ export const table: Array<[number, number, string, boolean?, boolean?]> = [
   [276, 0, 'p2p-webrtc-direct'],
   [277, 0, 'p2p-stardust'],
   [280, 0, 'webrtc'],
+  [281, 0, 'webrtc-direct'],
   [290, 0, 'p2p-circuit'],
   [301, 0, 'udt'],
   [302, 0, 'utp'],


### PR DESCRIPTION
Adds a new protocol called `webrtc-direct` for enabling webrtc browser-to-browser. https://github.com/libp2p/specs/pull/497