### PR TITLE
fix: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
   "dependencies": {
     "@chainsafe/is-ip": "^2.0.1",
     "@chainsafe/netmask": "^2.0.0",
+    "@libp2p/interfaces": "^3.3.1",
     "dns-over-http-resolver": "^2.1.0",
     "err-code": "^3.0.1",
     "multiformats": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "@chainsafe/netmask": "^2.0.0",
     "@libp2p/interfaces": "^3.3.1",
     "dns-over-http-resolver": "^2.1.0",
-    "err-code": "^3.0.1",
     "multiformats": "^11.0.0",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { getProtocol, names } from './protocols-table.js'
 import varint from 'varint'
 import { CID } from 'multiformats/cid'
 import { base58btc } from 'multiformats/bases/base58'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 
@@ -716,7 +716,7 @@ class DefaultMultiaddr implements Multiaddr {
 
     const resolver = resolvers.get(resolvableProto.name)
     if (resolver == null) {
-      throw errCode(new Error(`no available resolver for ${resolvableProto.name}`), 'ERR_NO_AVAILABLE_RESOLVER')
+      throw new CodeError(`no available resolver for ${resolvableProto.name}`, 'ERR_NO_AVAILABLE_RESOLVER')
     }
 
     const addresses = await resolver(this, options)


### PR DESCRIPTION
Related: https://github.com/libp2p/js-libp2p/issues/1269

- deps: install @libp2p/interfaces
- fix: replace err-code with CodeError
- deps: remove err-code
