### PR TITLE
feat: get path and tuples on constructor

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -68,17 +68,25 @@ export function stringTuplesToString (tuples: StringTuple[]): string {
 /**
  * [[str name, str addr]... ] -> [[int code, Uint8Array]... ]
  */
-export function stringTuplesToTuples (tuples: Array<string[] | string>): Tuple[] {
-  return tuples.map((tup) => {
+export function stringTuplesToTuples (stringTuples: Array<string[] | string>): { tuples: Tuple[], path: string | null } {
+  let path: string | null | undefined
+  const tuples = stringTuples.map((tup) => {
     if (!Array.isArray(tup)) {
       tup = [tup]
     }
     const proto = protoFromTuple(tup)
-    if (tup.length > 1) {
-      return [proto.code, convertToBytes(proto.code, tup[1])]
+    const tuple: Tuple = (tup.length > 1) ? [proto.code, convertToBytes(proto.code, tup[1])] : [proto.code]
+    if (path === undefined && proto.path === true) {
+      path = tuple[1] != null ? convertToString(proto.code, tuple[1]) : null
     }
-    return [proto.code]
+    return tuple
   })
+
+  if (path == null) {
+    path = null
+  }
+
+  return { tuples, path }
 }
 
 /**
@@ -171,18 +179,18 @@ export function bytesToString (buf: Uint8Array): string {
 /**
  * String -> Uint8Array
  */
-export function stringToBytes (str: string): Uint8Array {
+export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
   str = cleanPath(str)
-  const a = stringToStringTuples(str)
-  const b = stringTuplesToTuples(a)
+  const stringTuples = stringToStringTuples(str)
+  const { tuples, path } = stringTuplesToTuples(stringTuples)
 
-  return tuplesToBytes(b)
+  return { bytes: tuplesToBytes(tuples), tuples, path }
 }
 
 /**
  * String -> Uint8Array
  */
-export function fromString (str: string): Uint8Array {
+export function fromString (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
   return stringToBytes(str)
 }
 

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -3,7 +3,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import varint from 'varint'
 import { convertToBytes, convertToString } from './convert.js'
 import { getProtocol } from './protocols-table.js'
-import type { StringTuple, Tuple, Protocol } from './index.js'
+import type { StringTuple, Tuple, Protocol, MultiaddrInputString, MultiaddrInputStringResult } from './index.js'
 
 /**
  * string -> [[str name, str addr]... ]
@@ -66,9 +66,10 @@ export function stringTuplesToString (tuples: StringTuple[]): string {
 }
 
 /**
- * [[str name, str addr]... ] -> [[int code, Uint8Array]... ]
+ * [[str name, str addr]... ] -> {tuples: [[int code, Uint8Array]... ], path: str}
+ * The logic to get path is the same to DefaultMultiaddr.getPath()
  */
-export function stringTuplesToTuples (stringTuples: Array<string[] | string>): { tuples: Tuple[], path: string | null } {
+export function stringTuplesToTuples (stringTuples: Array<string[] | string>): Omit<MultiaddrInputStringResult, 'bytes'> {
   let path: string | null | undefined
   const tuples = stringTuples.map((tup) => {
     if (!Array.isArray(tup)) {
@@ -177,9 +178,9 @@ export function bytesToString (buf: Uint8Array): string {
 }
 
 /**
- * String -> Uint8Array
+ * MultiaddrInputString -> MultiaddrInputStringResult
  */
-export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
+export function parseMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
   str = cleanPath(str)
   const stringTuples = stringToStringTuples(str)
   const { tuples, path } = stringTuplesToTuples(stringTuples)
@@ -188,10 +189,10 @@ export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[
 }
 
 /**
- * String -> Uint8Array
+ * MultiaddrInputString -> MultiaddrInputStringResult
  */
-export function fromString (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
-  return stringToBytes(str)
+export function fromMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
+  return parseMultiaddrInputString(str)
 }
 
 /**

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -83,7 +83,7 @@ export function stringTuplesToTuples (stringTuples: Array<string[] | string>): O
     return tuple
   })
 
-  if (path == null) {
+  if (path === undefined) {
     path = null
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,10 @@ class DefaultMultiaddr implements Multiaddr {
       if (addr.length > 0 && addr.charAt(0) !== '/') {
         throw new Error(`multiaddr "${addr}" must start with a "/"`)
       }
-      this.bytes = codec.fromString(addr)
+      const { bytes, tuples, path } = codec.fromString(addr)
+      this.bytes = bytes
+      this.#tuples = tuples
+      this.#path = path
     } else if (isMultiaddr(addr)) { // Multiaddr
       this.bytes = codec.fromBytes(addr.bytes) // validate + copy buffer
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,14 @@ export interface NodeAddress {
 }
 
 /**
+ * Represent a multiaaddr input string
+ */
+export type MultiaddrInputString = string
+
+/**
  * These types can be parsed into a {@link Multiaddr} object
  */
-export type MultiaddrInput = string | Multiaddr | Uint8Array | null
+export type MultiaddrInput = MultiaddrInputString | Multiaddr | Uint8Array | null
 
 /**
  * A Resolver is a function that takes a {@link Multiaddr} and resolves it into one
@@ -80,6 +85,13 @@ export type Tuple = [number, Uint8Array?]
  * A code/value pair with the value as a string
  */
 export type StringTuple = [number, string?]
+
+/** The result of parsing a MultiaddrInput string */
+export interface MultiaddrInputStringResult {
+  bytes: Uint8Array
+  tuples: Tuple[]
+  path: string | null
+}
 
 /**
  * Allows aborting long-lived operations
@@ -513,7 +525,7 @@ class DefaultMultiaddr implements Multiaddr {
       if (addr.length > 0 && addr.charAt(0) !== '/') {
         throw new Error(`multiaddr "${addr}" must start with a "/"`)
       }
-      const { bytes, tuples, path } = codec.fromString(addr)
+      const { bytes, tuples, path } = codec.fromMultiaddrInputString(addr)
       this.bytes = bytes
       this.#tuples = tuples
       this.#path = path

--- a/test/codec.spec.ts
+++ b/test/codec.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import varint from 'varint'
 import * as codec from '../src/codec.js'
+import { convertToBytes } from '../src/convert.js'
 
 describe('codec', () => {
   describe('.stringToStringTuples', () => {
@@ -16,13 +17,20 @@ describe('codec', () => {
   })
 
   describe('.stringTuplesToTuples', () => {
-    it('handles non array tuples', () => {
-      expect(
-        codec.stringTuplesToTuples([['ip4', '0.0.0.0'], 'utp'])
-      ).to.eql(
-        [[4, Uint8Array.from([0, 0, 0, 0])], [302]]
-      )
-    })
+    const testCases: Array<{ name: string, stringTuples: Array<string[] | string>, tuples: Array<[number, Uint8Array?]>, path: string | null }> = [
+      { name: 'handles non array tuples', stringTuples: [['ip4', '0.0.0.0'], 'utp'], tuples: [[4, Uint8Array.from([0, 0, 0, 0])], [302]], path: null },
+      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' }
+    ]
+
+    for (const { name, stringTuples, tuples, path } of testCases) {
+      it(name, () => {
+        expect(
+          codec.stringTuplesToTuples(stringTuples)
+        ).to.eql(
+          { tuples, path }
+        )
+      })
+    }
   })
 
   describe('.tuplesToStringTuples', () => {

--- a/test/codec.spec.ts
+++ b/test/codec.spec.ts
@@ -19,7 +19,8 @@ describe('codec', () => {
   describe('.stringTuplesToTuples', () => {
     const testCases: Array<{ name: string, stringTuples: Array<string[] | string>, tuples: Array<[number, Uint8Array?]>, path: string | null }> = [
       { name: 'handles non array tuples', stringTuples: [['ip4', '0.0.0.0'], 'utp'], tuples: [[4, Uint8Array.from([0, 0, 0, 0])], [302]], path: null },
-      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' }
+      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' },
+      { name: 'should return the 1st path', stringTuples: [['unix', '/tmp/p2p.sock'], ['unix', '/tmp2/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')], [400, convertToBytes(400, '/tmp2/p2p.sock')]], path: '/tmp/p2p.sock' }
     ]
 
     for (const { name, stringTuples, tuples, path } of testCases) {


### PR DESCRIPTION
**Motivation**
- path and tuples could be computed in constructor when `MultiaddrInput` is a string
- this is for https://github.com/libp2p/js-libp2p-tcp/pull/264

**Description**
- during the creation of `DefaultMultiaddr` when  `MultiaddrInput` is a string, we already have tuples in  `stringTuplesToTuples`, just need to return it
- in that function, we already loop through each item,  just need to check each proto to return path