### PR TITLE
fix: precalculate multiaddr parts

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -68,17 +68,25 @@ export function stringTuplesToString (tuples: StringTuple[]): string {
 /**
  * [[str name, str addr]... ] -> [[int code, Uint8Array]... ]
  */
-export function stringTuplesToTuples (tuples: Array<string[] | string>): Tuple[] {
-  return tuples.map((tup) => {
+export function stringTuplesToTuples (stringTuples: Array<string[] | string>): { tuples: Tuple[], path: string | null } {
+  let path: string | null | undefined
+  const tuples = stringTuples.map((tup) => {
     if (!Array.isArray(tup)) {
       tup = [tup]
     }
     const proto = protoFromTuple(tup)
-    if (tup.length > 1) {
-      return [proto.code, convertToBytes(proto.code, tup[1])]
+    const tuple: Tuple = (tup.length > 1) ? [proto.code, convertToBytes(proto.code, tup[1])] : [proto.code]
+    if (path === undefined && proto.path === true) {
+      path = tuple[1] != null ? convertToString(proto.code, tuple[1]) : null
     }
-    return [proto.code]
+    return tuple
   })
+
+  if (path == null) {
+    path = null
+  }
+
+  return { tuples, path }
 }
 
 /**
@@ -171,18 +179,18 @@ export function bytesToString (buf: Uint8Array): string {
 /**
  * String -> Uint8Array
  */
-export function stringToBytes (str: string): Uint8Array {
+export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
   str = cleanPath(str)
-  const a = stringToStringTuples(str)
-  const b = stringTuplesToTuples(a)
+  const stringTuples = stringToStringTuples(str)
+  const { tuples, path } = stringTuplesToTuples(stringTuples)
 
-  return tuplesToBytes(b)
+  return { bytes: tuplesToBytes(tuples), tuples, path }
 }
 
 /**
  * String -> Uint8Array
  */
-export function fromString (str: string): Uint8Array {
+export function fromString (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
   return stringToBytes(str)
 }
 

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -3,16 +3,31 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import varint from 'varint'
 import { convertToBytes, convertToString } from './convert.js'
 import { getProtocol } from './protocols-table.js'
-import type { StringTuple, Tuple, Protocol, MultiaddrInputString, MultiaddrInputStringResult } from './index.js'
+import type { StringTuple, Tuple, Protocol } from './index.js'
 
-/**
- * string -> [[str name, str addr]... ]
- */
-export function stringToStringTuples (str: string): string[][] {
-  const tuples = []
-  const parts = str.split('/').slice(1) // skip first empty elem
+export interface MultiaddrParts {
+  bytes: Uint8Array
+  string: string
+  tuples: Tuple[]
+  stringTuples: StringTuple[]
+  path: string | null
+}
+
+export function stringToMultiaddrParts (str: string): MultiaddrParts {
+  str = cleanPath(str)
+  const tuples: Tuple[] = []
+  const stringTuples: StringTuple[] = []
+  let path: string | null = null
+
+  const parts = str.split('/').slice(1)
   if (parts.length === 1 && parts[0] === '') {
-    return []
+    return {
+      bytes: new Uint8Array(),
+      string: '/',
+      tuples: [],
+      stringTuples: [],
+      path: null
+    }
   }
 
   for (let p = 0; p < parts.length; p++) {
@@ -20,7 +35,8 @@ export function stringToStringTuples (str: string): string[][] {
     const proto = getProtocol(part)
 
     if (proto.size === 0) {
-      tuples.push([part])
+      tuples.push([proto.code])
+      stringTuples.push([proto.code])
       // eslint-disable-next-line no-continue
       continue
     }
@@ -32,29 +48,88 @@ export function stringToStringTuples (str: string): string[][] {
 
     // if it's a path proto, take the rest
     if (proto.path === true) {
-      tuples.push([
-        part,
-        // should we need to check each path part to see if it's a proto?
-        // This would allow for other protocols to be added after a unix path,
-        // however it would have issues if the path had a protocol name in the path
-        cleanPath(parts.slice(p).join('/'))
-      ])
+      // should we need to check each path part to see if it's a proto?
+      // This would allow for other protocols to be added after a unix path,
+      // however it would have issues if the path had a protocol name in the path
+      path = cleanPath(parts.slice(p).join('/'))
+      tuples.push([proto.code, convertToBytes(proto.code, path)])
+      stringTuples.push([proto.code, path])
       break
     }
 
-    tuples.push([part, parts[p]])
+    const bytes = convertToBytes(proto.code, parts[p])
+    tuples.push([proto.code, bytes])
+    stringTuples.push([proto.code, convertToString(proto.code, bytes)])
   }
 
-  return tuples
+  return {
+    string: stringTuplesToString(stringTuples),
+    bytes: tuplesToBytes(tuples),
+    tuples,
+    stringTuples,
+    path
+  }
+}
+
+export function bytesToMultiaddrParts (bytes: Uint8Array): MultiaddrParts {
+  const tuples: Tuple[] = []
+  const stringTuples: StringTuple[] = []
+  let path: string | null = null
+
+  let i = 0
+  while (i < bytes.length) {
+    const code = varint.decode(bytes, i)
+    const n = varint.decode.bytes ?? 0
+
+    const p = getProtocol(code)
+
+    const size = sizeForAddr(p, bytes.slice(i + n))
+
+    if (size === 0) {
+      tuples.push([code])
+      stringTuples.push([code])
+      i += n
+      // eslint-disable-next-line no-continue
+      continue
+    }
+
+    const addr = bytes.slice(i + n, i + n + size)
+
+    i += (size + n)
+
+    if (i > bytes.length) { // did not end _exactly_ at buffer.length
+      throw ParseError('Invalid address Uint8Array: ' + uint8ArrayToString(bytes, 'base16'))
+    }
+
+    // ok, tuple seems good.
+    tuples.push([code, addr])
+    const stringAddr = convertToString(code, addr)
+    stringTuples.push([code, stringAddr])
+    if (p.path === true) {
+      // should we need to check each path part to see if it's a proto?
+      // This would allow for other protocols to be added after a unix path,
+      // however it would have issues if the path had a protocol name in the path
+      path = stringAddr
+      break
+    }
+  }
+
+  return {
+    bytes: Uint8Array.from(bytes),
+    string: stringTuplesToString(stringTuples),
+    tuples,
+    stringTuples,
+    path
+  }
 }
 
 /**
  * [[str name, str addr]... ] -> string
  */
-export function stringTuplesToString (tuples: StringTuple[]): string {
+function stringTuplesToString (tuples: StringTuple[]): string {
   const parts: string[] = []
   tuples.map((tup) => {
-    const proto = protoFromTuple(tup)
+    const proto = getProtocol(tup[0])
     parts.push(proto.name)
     if (tup.length > 1 && tup[1] != null) {
       parts.push(tup[1])
@@ -66,51 +141,11 @@ export function stringTuplesToString (tuples: StringTuple[]): string {
 }
 
 /**
- * [[str name, str addr]... ] -> {tuples: [[int code, Uint8Array]... ], path: str}
- * The logic to get path is the same to DefaultMultiaddr.getPath()
- */
-export function stringTuplesToTuples (stringTuples: Array<string[] | string>): Omit<MultiaddrInputStringResult, 'bytes'> {
-  let path: string | null | undefined
-  const tuples = stringTuples.map((tup) => {
-    if (!Array.isArray(tup)) {
-      tup = [tup]
-    }
-    const proto = protoFromTuple(tup)
-    const tuple: Tuple = (tup.length > 1) ? [proto.code, convertToBytes(proto.code, tup[1])] : [proto.code]
-    if (path === undefined && proto.path === true) {
-      path = tuple[1] != null ? convertToString(proto.code, tuple[1]) : null
-    }
-    return tuple
-  })
-
-  if (path === undefined) {
-    path = null
-  }
-
-  return { tuples, path }
-}
-
-/**
- * Convert tuples to string tuples
- *
- * [[int code, Uint8Array]... ] -> [[int code, str addr]... ]
- */
-export function tuplesToStringTuples (tuples: Tuple[]): StringTuple[] {
-  return tuples.map(tup => {
-    const proto = protoFromTuple(tup)
-    if (tup[1] != null) {
-      return [proto.code, convertToString(proto.code, tup[1])]
-    }
-    return [proto.code]
-  })
-}
-
-/**
  * [[int code, Uint8Array ]... ] -> Uint8Array
  */
 export function tuplesToBytes (tuples: Tuple[]): Uint8Array {
-  return fromBytes(uint8ArrayConcat(tuples.map((tup) => {
-    const proto = protoFromTuple(tup)
+  return uint8ArrayConcat(tuples.map((tup) => {
+    const proto = getProtocol(tup[0])
     let buf = Uint8Array.from(varint.encode(proto.code))
 
     if (tup.length > 1 && tup[1] != null) {
@@ -118,13 +153,13 @@ export function tuplesToBytes (tuples: Tuple[]): Uint8Array {
     }
 
     return buf
-  })))
+  }))
 }
 
 /**
  * For the passed address, return the serialized size
  */
-export function sizeForAddr (p: Protocol, addr: Uint8Array | number[]): number {
+function sizeForAddr (p: Protocol, addr: Uint8Array | number[]): number {
   if (p.size > 0) {
     return p.size / 8
   } else if (p.size === 0) {
@@ -168,65 +203,10 @@ export function bytesToTuples (buf: Uint8Array): Tuple[] {
   return tuples
 }
 
-/**
- * Uint8Array -> String
- */
-export function bytesToString (buf: Uint8Array): string {
-  const a = bytesToTuples(buf)
-  const b = tuplesToStringTuples(a)
-  return stringTuplesToString(b)
-}
-
-/**
- * MultiaddrInputString -> MultiaddrInputStringResult
- */
-export function parseMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
-  str = cleanPath(str)
-  const stringTuples = stringToStringTuples(str)
-  const { tuples, path } = stringTuplesToTuples(stringTuples)
-
-  return { bytes: tuplesToBytes(tuples), tuples, path }
-}
-
-/**
- * MultiaddrInputString -> MultiaddrInputStringResult
- */
-export function fromMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
-  return parseMultiaddrInputString(str)
-}
-
-/**
- * Uint8Array -> Uint8Array
- */
-export function fromBytes (buf: Uint8Array): Uint8Array {
-  const err = validateBytes(buf)
-  if (err != null) {
-    throw err
-  }
-  return Uint8Array.from(buf) // copy
-}
-
-export function validateBytes (buf: Uint8Array): Error | undefined {
-  try {
-    bytesToTuples(buf) // try to parse. will throw if breaks
-  } catch (err: any) {
-    return err
-  }
-}
-
-export function isValidBytes (buf: Uint8Array): boolean {
-  return validateBytes(buf) === undefined
-}
-
 export function cleanPath (str: string): string {
   return '/' + str.trim().split('/').filter((a) => a).join('/')
 }
 
 export function ParseError (str: string): Error {
   return new Error('Error parsing address: ' + str)
-}
-
-export function protoFromTuple (tup: any[]): Protocol {
-  const proto = getProtocol(tup[0])
-  return proto
 }

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -3,7 +3,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import varint from 'varint'
 import { convertToBytes, convertToString } from './convert.js'
 import { getProtocol } from './protocols-table.js'
-import type { StringTuple, Tuple, Protocol } from './index.js'
+import type { StringTuple, Tuple, Protocol, MultiaddrInputString, MultiaddrInputStringResult } from './index.js'
 
 /**
  * string -> [[str name, str addr]... ]
@@ -66,9 +66,10 @@ export function stringTuplesToString (tuples: StringTuple[]): string {
 }
 
 /**
- * [[str name, str addr]... ] -> [[int code, Uint8Array]... ]
+ * [[str name, str addr]... ] -> {tuples: [[int code, Uint8Array]... ], path: str}
+ * The logic to get path is the same to DefaultMultiaddr.getPath()
  */
-export function stringTuplesToTuples (stringTuples: Array<string[] | string>): { tuples: Tuple[], path: string | null } {
+export function stringTuplesToTuples (stringTuples: Array<string[] | string>): Omit<MultiaddrInputStringResult, 'bytes'> {
   let path: string | null | undefined
   const tuples = stringTuples.map((tup) => {
     if (!Array.isArray(tup)) {
@@ -177,9 +178,9 @@ export function bytesToString (buf: Uint8Array): string {
 }
 
 /**
- * String -> Uint8Array
+ * MultiaddrInputString -> MultiaddrInputStringResult
  */
-export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
+export function parseMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
   str = cleanPath(str)
   const stringTuples = stringToStringTuples(str)
   const { tuples, path } = stringTuplesToTuples(stringTuples)
@@ -188,10 +189,10 @@ export function stringToBytes (str: string): { bytes: Uint8Array, tuples: Tuple[
 }
 
 /**
- * String -> Uint8Array
+ * MultiaddrInputString -> MultiaddrInputStringResult
  */
-export function fromString (str: string): { bytes: Uint8Array, tuples: Tuple[], path: string | null } {
-  return stringToBytes(str)
+export function fromMultiaddrInputString (str: MultiaddrInputString): MultiaddrInputStringResult {
+  return parseMultiaddrInputString(str)
 }
 
 /**

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -83,7 +83,7 @@ export function stringTuplesToTuples (stringTuples: Array<string[] | string>): O
     return tuple
   })
 
-  if (path == null) {
+  if (path === undefined) {
     path = null
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,10 @@ class DefaultMultiaddr implements Multiaddr {
       if (addr.length > 0 && addr.charAt(0) !== '/') {
         throw new Error(`multiaddr "${addr}" must start with a "/"`)
       }
-      this.bytes = codec.fromString(addr)
+      const { bytes, tuples, path } = codec.fromString(addr)
+      this.bytes = bytes
+      this.#tuples = tuples
+      this.#path = path
     } else if (isMultiaddr(addr)) { // Multiaddr
       this.bytes = codec.fromBytes(addr.bytes) // validate + copy buffer
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,14 @@ export interface NodeAddress {
 }
 
 /**
+ * Represent a multiaaddr input string
+ */
+export type MultiaddrInputString = string
+
+/**
  * These types can be parsed into a {@link Multiaddr} object
  */
-export type MultiaddrInput = string | Multiaddr | Uint8Array | null
+export type MultiaddrInput = MultiaddrInputString | Multiaddr | Uint8Array | null
 
 /**
  * A Resolver is a function that takes a {@link Multiaddr} and resolves it into one
@@ -80,6 +85,13 @@ export type Tuple = [number, Uint8Array?]
  * A code/value pair with the value as a string
  */
 export type StringTuple = [number, string?]
+
+/** The result of parsing a MultiaddrInput string */
+export interface MultiaddrInputStringResult {
+  bytes: Uint8Array
+  tuples: Tuple[]
+  path: string | null
+}
 
 /**
  * Allows aborting long-lived operations
@@ -513,7 +525,7 @@ class DefaultMultiaddr implements Multiaddr {
       if (addr.length > 0 && addr.charAt(0) !== '/') {
         throw new Error(`multiaddr "${addr}" must start with a "/"`)
       }
-      const { bytes, tuples, path } = codec.fromString(addr)
+      const { bytes, tuples, path } = codec.fromMultiaddrInputString(addr)
       this.bytes = bytes
       this.#tuples = tuples
       this.#path = path

--- a/test/codec.spec.ts
+++ b/test/codec.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import varint from 'varint'
 import * as codec from '../src/codec.js'
+import { convertToBytes } from '../src/convert.js'
 
 describe('codec', () => {
   describe('.stringToStringTuples', () => {
@@ -16,13 +17,20 @@ describe('codec', () => {
   })
 
   describe('.stringTuplesToTuples', () => {
-    it('handles non array tuples', () => {
-      expect(
-        codec.stringTuplesToTuples([['ip4', '0.0.0.0'], 'utp'])
-      ).to.eql(
-        [[4, Uint8Array.from([0, 0, 0, 0])], [302]]
-      )
-    })
+    const testCases: Array<{ name: string, stringTuples: Array<string[] | string>, tuples: Array<[number, Uint8Array?]>, path: string | null }> = [
+      { name: 'handles non array tuples', stringTuples: [['ip4', '0.0.0.0'], 'utp'], tuples: [[4, Uint8Array.from([0, 0, 0, 0])], [302]], path: null },
+      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' }
+    ]
+
+    for (const { name, stringTuples, tuples, path } of testCases) {
+      it(name, () => {
+        expect(
+          codec.stringTuplesToTuples(stringTuples)
+        ).to.eql(
+          { tuples, path }
+        )
+      })
+    }
   })
 
   describe('.tuplesToStringTuples', () => {

--- a/test/codec.spec.ts
+++ b/test/codec.spec.ts
@@ -19,7 +19,8 @@ describe('codec', () => {
   describe('.stringTuplesToTuples', () => {
     const testCases: Array<{ name: string, stringTuples: Array<string[] | string>, tuples: Array<[number, Uint8Array?]>, path: string | null }> = [
       { name: 'handles non array tuples', stringTuples: [['ip4', '0.0.0.0'], 'utp'], tuples: [[4, Uint8Array.from([0, 0, 0, 0])], [302]], path: null },
-      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' }
+      { name: 'handle not null path', stringTuples: [['unix', '/tmp/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')]], path: '/tmp/p2p.sock' },
+      { name: 'should return the 1st path', stringTuples: [['unix', '/tmp/p2p.sock'], ['unix', '/tmp2/p2p.sock']], tuples: [[400, convertToBytes(400, '/tmp/p2p.sock')], [400, convertToBytes(400, '/tmp2/p2p.sock')]], path: '/tmp/p2p.sock' }
     ]
 
     for (const { name, stringTuples, tuples, path } of testCases) {


### PR DESCRIPTION
Taking #329 to its logical extreme, we're able to simplify the codebase (mostly `codec.ts` and its interaction with `DefaultMultiaddr`).

Precalculate a `MultiaddrParts` when constructing a `DefaultMultiaddr`.
`MultiaddrParts` is essentially an object containing all data which is stored in a `DefaultMultiaddr`.

This makes all `DefaultMultiaddr` methods cheap, at the expense of always storing the string, bytes, tuples, stringTuples, and path of the multiaddr.

The two important functions to review are `stringToMultiaddrParts` and `bytesToMultiaddrParts`, which convert untrusted string and bytes into `MultiaddrParts`.

cc @tuyennhv 