### PR TITLE
feat(resolve): allow configurable dnsServers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -692,7 +692,7 @@ class DefaultMultiaddr implements Multiaddr {
     return uint8ArrayEquals(this.bytes, addr.bytes)
   }
 
-  async resolve (options?: AbortOptions & ResolverOptions ): Promise<Multiaddr[]> {
+  async resolve (options?: AbortOptions & ResolverOptions): Promise<Multiaddr[]> {
     const resolvableProto = this.protos().find((p) => p.resolvable)
 
     // Multiaddr is not resolvable?

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export type MultiaddrInput = string | Multiaddr | Uint8Array | null
  * A Resolver is a function that takes a {@link Multiaddr} and resolves it into one
  * or more string representations of that {@link Multiaddr}.
  */
-export interface Resolver { (addr: Multiaddr, options?: AbortOptions): Promise<string[]> }
+export interface Resolver { (addr: Multiaddr, options?: AbortOptions & ResolverOptions): Promise<string[]> }
 
 /**
  * A code/value pair
@@ -85,6 +85,20 @@ export type StringTuple = [number, string?]
  */
 export interface AbortOptions {
   signal?: AbortSignal
+}
+
+/**
+ * Options for DNS resolvers.
+ * dns-over-http-resolver in the browser and 'node:dns' in Node.js
+ */
+export interface ResolverOptions {
+  /**
+   * DNS servers to use for resolution.
+   *
+   * In the browser, this is passed to dns-over-http-resolver, so the servers should be a DoH compatible url such as https://cloudflare-dns.com/dns-query
+   * In Node.js, this is passed to dns.resolve, so the servers should be an IP address or hostname (with optional port) such as '9.9.9.9'
+   */
+  dnsServers?: string[]
 }
 
 /**
@@ -351,7 +365,7 @@ export interface Multiaddr {
    * // ]
    * ```
    */
-  resolve: (options?: AbortOptions) => Promise<Multiaddr[]>
+  resolve: (options?: AbortOptions & ResolverOptions) => Promise<Multiaddr[]>
 
   /**
    * Gets a Multiaddrs node-friendly address object. Note that protocol information
@@ -678,7 +692,7 @@ class DefaultMultiaddr implements Multiaddr {
     return uint8ArrayEquals(this.bytes, addr.bytes)
   }
 
-  async resolve (options?: AbortOptions): Promise<Multiaddr[]> {
+  async resolve (options?: AbortOptions & ResolverOptions ): Promise<Multiaddr[]> {
     const resolvableProto = this.protos().find((p) => p.resolvable)
 
     // Multiaddr is not resolvable?

--- a/src/resolvers/dns.ts
+++ b/src/resolvers/dns.ts
@@ -1,3 +1,3 @@
-import { Resolver } from 'dns/promises'
+import { Resolver } from 'node:dns/promises'
 
 export default Resolver

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -6,7 +6,7 @@
 
 import { getProtocol } from '../protocols-table.js'
 import Resolver from './dns.js'
-import type { AbortOptions, Multiaddr } from '../index.js'
+import type { AbortOptions, Multiaddr, ResolverOptions } from '../index.js'
 
 const { code: dnsaddrCode } = getProtocol('dnsaddr')
 
@@ -31,8 +31,11 @@ const { code: dnsaddrCode } = getProtocol('dnsaddr')
  * //]
  * ```
  */
-export async function dnsaddrResolver (addr: Multiaddr, options: AbortOptions = {}): Promise<string[]> {
+export async function dnsaddrResolver (addr: Multiaddr, options: AbortOptions & ResolverOptions = {}): Promise<string[]> {
   const resolver = new Resolver()
+  if (options.dnsServers != null) {
+    resolver.setServers(options.dnsServers)
+  }
 
   if (options.signal != null) {
     options.signal.addEventListener('abort', () => {


### PR DESCRIPTION

This change allows users to call ma.resolve() with a dnsServers option that
will allow them to override the dnsServers used when resolving /dnsaddr/xxx multiaddrs.
