### PR TITLE
deps: bump dns-over-http-resolver to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "@chainsafe/is-ip": "^2.0.1",
     "@chainsafe/netmask": "^2.0.0",
     "@libp2p/interface": "^0.1.1",
-    "dns-over-http-resolver": "^2.1.0",
+    "dns-over-http-resolver": "3.0.0",
     "multiformats": "^12.0.1",
     "uint8-varint": "^2.0.1",
     "uint8arrays": "^4.0.2"


### PR DESCRIPTION
This removes [undici](https://www.npmjs.com/package/undici) as a  peer dependency 