### PR TITLE
feat: accept DNS resolver when resolving DNSADDR addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A standard way to represent addresses that
 
 ## Example
 
-```js
+```TypeScript
 import { multiaddr } from '@multiformats/multiaddr'
 const addr =  multiaddr("/ip4/127.0.0.1/udp/1234")
 // Multiaddr(/ip4/127.0.0.1/udp/1234)
@@ -65,25 +65,52 @@ addr.encapsulate('/sctp/5678')
 // Multiaddr(/ip4/127.0.0.1/udp/1234/sctp/5678)
 ```
 
-## Resolvers
+## Resolving DNSADDR addresses
 
-`multiaddr` allows multiaddrs to be resolved when appropriate resolvers are provided. This module already has resolvers available, but you can also create your own.  Resolvers should always be set in the same module that is calling `multiaddr.resolve()` to avoid conflicts if multiple versions of `multiaddr` are in your dependency tree.
+[DNSADDR](https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md) is a spec that allows storing a TXT DNS record that contains a Multiaddr.
 
-To provide multiaddr resolvers you can do:
+To resolve DNSADDR addresses, call the `.resolve()` function the multiaddr, optionally passing a `DNS` resolver.
 
-```js
-import { resolvers  } from '@multiformats/multiaddr'
+DNSADDR addresses can resolve to multiple multiaddrs, since there is no limit to the number of TXT records that can be stored.
 
-resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
+## Example - Resolving DNSADDR Multiaddrs
+
+```TypeScript
+import { multiaddr, resolvers } from '@multiformats/multiaddr'
+import { dnsaddr } from '@multiformats/multiaddr/resolvers'
+
+resolvers.set('dnsaddr', dnsaddr)
+
+const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+// resolve with a 5s timeout
+const resolved = await ma.resolve({
+  signal: AbortSignal.timeout(5000)
+})
+
+console.info(await ma.resolve(resolved)
+// [Multiaddr('/ip4/147.75...'), Multiaddr('/ip4/147.75...'), Multiaddr('/ip4/147.75...')...]
 ```
 
-The available resolvers are:
+## Example - Using a custom DNS resolver to resolve DNSADDR Multiaddrs
 
-| Name              | type      | Description                         |
-| ----------------- | --------- | ----------------------------------- |
-| `dnsaddrResolver` | `dnsaddr` | dnsaddr resolution with TXT Records |
+```TypeScript
+import { multiaddr } from '@multiformats/multiaddr'
+import { dns } from '@multiformats/dns'
+import { dnsJsonOverHttps } from '@multiformats/dns/resolvers'
 
-A resolver receives a `Multiaddr` as a parameter and returns a `Promise<Array<string>>`.
+const resolver = dns({
+  '.': dnsJsonOverHttps('https://cloudflare-dns.com/dns-query')
+})
+
+const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+const resolved = await ma.resolve({
+ dns: resolver
+})
+
+console.info(resolved)
+// [Multiaddr('/ip4/147.75...'), Multiaddr('/ip4/147.75...'), Multiaddr('/ip4/147.75...')...]
+```
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ console.info(await ma.resolve(resolved)
 
 ## Example - Using a custom DNS resolver to resolve DNSADDR Multiaddrs
 
+See the docs for [@multiformats/dns](https://www.npmjs.com/package/@multiformats/dns) for a full breakdown of how to specify multiple resolvers or resolvers that can be used for specific TLDs.
+
 ```TypeScript
 import { multiaddr } from '@multiformats/multiaddr'
 import { dns } from '@multiformats/dns'

--- a/package.json
+++ b/package.json
@@ -169,15 +169,17 @@
     "@chainsafe/is-ip": "^2.0.1",
     "@chainsafe/netmask": "^2.0.0",
     "@libp2p/interface": "^1.0.0",
-    "dns-over-http-resolver": "^3.0.2",
+    "@multiformats/dns": "^1.0.1",
     "multiformats": "^13.0.0",
+    "race-signal": "^1.0.2",
     "uint8-varint": "^2.0.1",
     "uint8arrays": "^5.0.0"
   },
   "devDependencies": {
     "@types/sinon": "^17.0.2",
     "aegir": "^42.2.2",
-    "sinon": "^17.0.0"
+    "sinon": "^17.0.0",
+    "sinon-ts": "^2.0.0"
   },
   "browser": {
     "./dist/src/resolvers/dns.js": "./dist/src/resolvers/dns.browser.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,8 @@ export interface AbortOptions {
  */
 export const resolvers = new Map<string, Resolver>()
 
+export type { Resolver }
+
 export { MultiaddrFilter } from './filter/multiaddr-filter.js'
 
 export interface ResolveOptions extends AbortOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@
  *
  * @example Using a custom DNS resolver to resolve DNSADDR Multiaddrs
  *
+ * See the docs for [@multiformats/dns](https://www.npmjs.com/package/@multiformats/dns) for a full breakdown of how to specify multiple resolvers or resolvers that can be used for specific TLDs.
+ *
  * ```TypeScript
  * import { multiaddr } from '@multiformats/multiaddr'
  * import { dns } from '@multiformats/dns'

--- a/src/multiaddr.ts
+++ b/src/multiaddr.ts
@@ -19,7 +19,7 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { bytesToMultiaddrParts, stringToMultiaddrParts, type MultiaddrParts, tuplesToBytes } from './codec.js'
 import { getProtocol, names } from './protocols-table.js'
-import { isMultiaddr, resolvers } from './index.js'
+import { isMultiaddr, multiaddr, resolvers } from './index.js'
 import type { MultiaddrInput, Multiaddr as MultiaddrInterface, MultiaddrObject, Protocol, StringTuple, Tuple, NodeAddress, ResolveOptions } from './index.js'
 
 const inspect = Symbol.for('nodejs.util.inspect.custom')
@@ -235,7 +235,9 @@ export class Multiaddr implements MultiaddrInterface {
       throw new CodeError(`no available resolver for ${resolvableProto.name}`, 'ERR_NO_AVAILABLE_RESOLVER')
     }
 
-    return resolver(this, options)
+    const result = await resolver(this, options)
+
+    return result.map(str => multiaddr(str))
   }
 
   nodeAddress (): NodeAddress {

--- a/src/multiaddr.ts
+++ b/src/multiaddr.ts
@@ -19,7 +19,8 @@ import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { bytesToMultiaddrParts, stringToMultiaddrParts, type MultiaddrParts, tuplesToBytes } from './codec.js'
 import { getProtocol, names } from './protocols-table.js'
-import { isMultiaddr, type AbortOptions, type MultiaddrInput, type Multiaddr as MultiaddrInterface, type MultiaddrObject, type Protocol, type StringTuple, type Tuple, resolvers, type NodeAddress } from './index.js'
+import { isMultiaddr, resolvers } from './index.js'
+import type { MultiaddrInput, Multiaddr as MultiaddrInterface, MultiaddrObject, Protocol, StringTuple, Tuple, NodeAddress, ResolveOptions } from './index.js'
 
 const inspect = Symbol.for('nodejs.util.inspect.custom')
 export const symbol = Symbol.for('@multiformats/js-multiaddr/multiaddr')
@@ -221,7 +222,7 @@ export class Multiaddr implements MultiaddrInterface {
     return uint8ArrayEquals(this.bytes, addr.bytes)
   }
 
-  async resolve (options?: AbortOptions): Promise<Multiaddr[]> {
+  async resolve (options?: ResolveOptions): Promise<MultiaddrInterface[]> {
     const resolvableProto = this.protos().find((p) => p.resolvable)
 
     // Multiaddr is not resolvable?
@@ -234,8 +235,7 @@ export class Multiaddr implements MultiaddrInterface {
       throw new CodeError(`no available resolver for ${resolvableProto.name}`, 'ERR_NO_AVAILABLE_RESOLVER')
     }
 
-    const addresses = await resolver(this, options)
-    return addresses.map((a) => new Multiaddr(a))
+    return resolver(this, options)
   }
 
   nodeAddress (): NodeAddress {

--- a/src/resolvers/dns.browser.ts
+++ b/src/resolvers/dns.browser.ts
@@ -1,3 +1,0 @@
-import dns from 'dns-over-http-resolver'
-
-export default dns

--- a/src/resolvers/dns.ts
+++ b/src/resolvers/dns.ts
@@ -1,3 +1,0 @@
-import { Resolver } from 'dns/promises'
-
-export default Resolver

--- a/src/resolvers/dnsaddr.ts
+++ b/src/resolvers/dnsaddr.ts
@@ -25,7 +25,7 @@ export interface DNSADDROptions extends AbortOptions {
   maxRecursiveDepth?: number
 }
 
-export const dnsaddr: Resolver<DNSADDROptions> = async function dnsaddr (ma: Multiaddr, options: DNSADDROptions = {}): Promise<Multiaddr[]> {
+export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddr (ma: Multiaddr, options: DNSADDROptions = {}): Promise<string[]> {
   const recursionLimit = options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH
 
   if (recursionLimit === 0) {
@@ -43,7 +43,7 @@ export const dnsaddr: Resolver<DNSADDROptions> = async function dnsaddr (ma: Mul
   }), options.signal)
 
   const peerId = ma.getPeerId()
-  const output: Multiaddr[] = []
+  const output: string[] = []
 
   for (const answer of result.Answer) {
     const addr = answer.data.split('=')[1]
@@ -64,9 +64,9 @@ export const dnsaddr: Resolver<DNSADDROptions> = async function dnsaddr (ma: Mul
         maxRecursiveDepth: recursionLimit - 1
       })
 
-      output.push(...resolved)
+      output.push(...resolved.map(ma => ma.toString()))
     } else {
-      output.push(ma)
+      output.push(ma.toString())
     }
   }
 

--- a/src/resolvers/dnsaddr.ts
+++ b/src/resolvers/dnsaddr.ts
@@ -1,0 +1,74 @@
+import { CodeError } from '@libp2p/interface'
+import { dns, RecordType } from '@multiformats/dns'
+import { raceSignal } from 'race-signal'
+import { multiaddr } from '../index.js'
+import { getProtocol } from '../protocols-table.js'
+import type { Resolver } from './index.js'
+import type { AbortOptions, Multiaddr } from '../index.js'
+import type { DNS } from '@multiformats/dns'
+
+const MAX_RECURSIVE_DEPTH = 32
+const { code: dnsaddrCode } = getProtocol('dnsaddr')
+
+export interface DNSADDROptions extends AbortOptions {
+  /**
+   * An optional DNS resolver
+   */
+  dns?: DNS
+
+  /**
+   * When resolving DNSADDR Multiaddrs that resolve to other DNSADDR Multiaddrs,
+   * limit how many times we will recursively resolve them.
+   *
+   * @default 32
+   */
+  maxRecursiveDepth?: number
+}
+
+export const dnsaddr: Resolver<DNSADDROptions> = async function dnsaddr (ma: Multiaddr, options: DNSADDROptions = {}): Promise<Multiaddr[]> {
+  const recursionLimit = options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH
+
+  if (recursionLimit === 0) {
+    throw new CodeError('Max recursive depth reached', 'ERR_MAX_RECURSIVE_DEPTH_REACHED')
+  }
+
+  const [, hostname] = ma.stringTuples().find(([proto]) => proto === dnsaddrCode) ?? []
+
+  const resolver = options?.dns ?? dns()
+  const result = await raceSignal(resolver.query(`_dnsaddr.${hostname}`, {
+    signal: options?.signal,
+    types: [
+      RecordType.TXT
+    ]
+  }), options.signal)
+
+  const peerId = ma.getPeerId()
+  const output: Multiaddr[] = []
+
+  for (const answer of result.Answer) {
+    const addr = answer.data.split('=')[1]
+
+    if (addr == null) {
+      continue
+    }
+
+    if (peerId != null && !addr.includes(peerId)) {
+      continue
+    }
+
+    const ma = multiaddr(addr)
+
+    if (addr.startsWith('/dnsaddr')) {
+      const resolved = await ma.resolve({
+        ...options,
+        maxRecursiveDepth: recursionLimit - 1
+      })
+
+      output.push(...resolved)
+    } else {
+      output.push(ma)
+    }
+  }
+
+  return output
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,7 +1,7 @@
 import type { AbortOptions, Multiaddr } from '../index.js'
 
 export interface Resolver<ResolveOptions extends AbortOptions = AbortOptions> {
-  (ma: Multiaddr, options?: ResolveOptions): Promise<Multiaddr[]>
+  (ma: Multiaddr, options?: ResolveOptions): Promise<string[]>
 }
 
-export { dnsaddr } from './dnsaddr.js'
+export { dnsaddrResolver } from './dnsaddr.js'

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,59 +1,7 @@
-/**
- * @packageDocumentation
- *
- * Provides strategies for resolving multiaddrs.
- */
-
-import { getProtocol } from '../protocols-table.js'
-import Resolver from './dns.js'
 import type { AbortOptions, Multiaddr } from '../index.js'
 
-const { code: dnsaddrCode } = getProtocol('dnsaddr')
-
-/**
- * Resolver for dnsaddr addresses.
- *
- * @example
- *
- * ```typescript
- * import { dnsaddrResolver } from '@multiformats/multiaddr/resolvers'
- * import { multiaddr } from '@multiformats/multiaddr'
- *
- * const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
- * const addresses = await dnsaddrResolver(ma)
- *
- * console.info(addresses)
- * //[
- * //  '/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
- * //  '/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
- * //  '/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt',
- * //  '/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'
- * //]
- * ```
- */
-export async function dnsaddrResolver (addr: Multiaddr, options: AbortOptions = {}): Promise<string[]> {
-  const resolver = new Resolver()
-
-  if (options.signal != null) {
-    options.signal.addEventListener('abort', () => {
-      resolver.cancel()
-    })
-  }
-
-  const peerId = addr.getPeerId()
-  const [, hostname] = addr.stringTuples().find(([proto]) => proto === dnsaddrCode) ?? []
-
-  if (hostname == null) {
-    throw new Error('No hostname found in multiaddr')
-  }
-
-  const records = await resolver.resolveTxt(`_dnsaddr.${hostname}`)
-
-  let addresses = records.flat().map((a) => a.split('=')[1]).filter(Boolean)
-
-  if (peerId != null) {
-    addresses = addresses.filter((entry) => entry.includes(peerId))
-  }
-
-  return addresses
+export interface Resolver<ResolveOptions extends AbortOptions = AbortOptions> {
+  (ma: Multiaddr, options?: ResolveOptions): Promise<Multiaddr[]>
 }
+
+export { dnsaddr } from './dnsaddr.js'

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -1,39 +1,72 @@
-/* eslint-env mocha */
+import { RecordType } from '@multiformats/dns'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
+import { stubInterface, type StubbedInstance } from 'sinon-ts'
 import { multiaddr, resolvers } from '../src/index.js'
-import Resolver from '../src/resolvers/dns.js'
-import * as resolversInternal from '../src/resolvers/index.js'
+import { dnsaddr } from '../src/resolvers/index.js'
+import type { DNS } from '@multiformats/dns'
 
-const dnsaddrStub1 = [
-  ['dnsaddr=/dnsaddr/ams-1.bootstrap.libp2p.io/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd'],
-  ['dnsaddr=/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/dnsaddr/lon-1.bootstrap.libp2p.io/p2p/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3'],
-  ['dnsaddr=/dnsaddr/nrt-1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'],
-  ['dnsaddr=/dnsaddr/nyc-1.bootstrap.libp2p.io/p2p/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm'],
-  ['dnsaddr=/dnsaddr/sfo-2.bootstrap.libp2p.io/p2p/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z']
-]
-
-const dnsaddrStub2 = [
-  ['dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb']
-]
-
-const dnsaddrStub3 = [
-  ['dnsaddr=/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'],
-  ['dnsaddr=/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa'],
-  ['dnsaddr_record_value'],
-  ['dnsaddr=/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'],
-  ['dnsaddr=/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt']
-]
+const stubs: Record<string, string[]> = {
+  '_dnsaddr.bootstrap.libp2p.io': [
+    'dnsaddr=/dnsaddr/ams-1.bootstrap.libp2p.io/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ],
+  '_dnsaddr.ams-1.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd'
+  ],
+  '_dnsaddr.ams-2.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip4/147.75.83.83/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip4/147.75.83.83/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/443/wss/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/ip6/2604:1380:2000:7a00::1/udp/4001/quic/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ],
+  '_dnsaddr.bad-addrs.libp2p.io': [
+    'dnsaddr=/dnsaddr/sv15.bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN',
+    'dnsaddr=/dnsaddr/ny5.bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa',
+    'dnsaddr_record_value',
+    'dnsaddr=/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb',
+    'dnsaddr=/dnsaddr/sg1.bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt'
+  ],
+  '_dnsaddr.am6.bootstrap.libp2p.io': [
+    'dnsaddr=/ip4/147.75.83.83/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'
+  ]
+}
 
 describe('multiaddr resolve', () => {
+  let dns: StubbedInstance<DNS>
+
+  beforeEach(() => {
+    dns = stubInterface<DNS>({
+      query: sinon.stub().callsFake((domain) => {
+        if (stubs[domain] != null) {
+          return {
+            Answer: stubs[domain].map(data => ({
+              name: '_dnsaddr.bootstrap.libp2p.io',
+              type: RecordType.TXT,
+              ttl: 100,
+              data
+            }))
+          }
+        }
+
+        throw new Error(`No result stubbed for ${domain}`)
+      })
+    })
+
+    resolvers.set('dnsaddr', dnsaddr)
+  })
+
   it('should throw if no resolver is available', async () => {
     const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+    resolvers.clear()
 
     // Resolve
     await expect(ma.resolve()).to.eventually.be.rejected()
@@ -41,11 +74,6 @@ describe('multiaddr resolve', () => {
   })
 
   describe('dnsaddr', () => {
-    before(() => {
-      // Set resolvers
-      resolvers.set('dnsaddr', resolversInternal.dnsaddrResolver)
-    })
-
     afterEach(() => {
       sinon.restore()
     })
@@ -53,71 +81,41 @@ describe('multiaddr resolve', () => {
     it('can resolve dnsaddr without no peerId', async () => {
       const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
 
-      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
-      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
-
       // Resolve
-      const resolvedMas = await ma.resolve()
-
-      expect(resolvedMas).to.have.length(dnsaddrStub1.length)
-      resolvedMas.forEach((ma, index) => {
-        const stubAddr = dnsaddrStub1[index][0].split('=')[1]
-
-        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
+      const resolvedMas = await ma.resolve({
+        dns
       })
+
+      expect(resolvedMas).to.deep.equal([
+        ...stubs['_dnsaddr.ams-1.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop())),
+        ...stubs['_dnsaddr.ams-2.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop()))
+      ])
     })
 
     it('can resolve dnsaddr with peerId', async () => {
       const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
 
-      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
-      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
-      stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
-
       // Resolve
-      const resolvedMas = await ma.resolve()
-
-      expect(resolvedMas).to.have.length(1)
-      expect(resolvedMas[0].equals(multiaddr('/dnsaddr/ams-2.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb'))).to.eql(true)
-    })
-
-    it('can resolve dnsaddr with peerId two levels', async () => {
-      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
-
-      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
-      stub.onCall(0).returns(Promise.resolve(dnsaddrStub1))
-      stub.onCall(1).returns(Promise.resolve(dnsaddrStub2))
-
-      // Resolve
-      const resolvedInitialMas = await ma.resolve()
-      const resolvedSecondMas = await Promise.all(resolvedInitialMas.map(async nm => {
-        //  nm.resolvers.set('dnsaddr', resolvers.dnsaddrResolver)
-        return nm.resolve()
-      }))
-
-      const resolvedMas = resolvedSecondMas.flat()
-
-      expect(resolvedMas).to.have.length(dnsaddrStub2.length)
-
-      resolvedMas.forEach((ma, index) => {
-        const stubAddr = dnsaddrStub2[index][0].split('=')[1]
-
-        expect(ma.equals(multiaddr(stubAddr))).to.equal(true)
+      const resolvedMas = await ma.resolve({
+        dns
       })
+
+      expect(resolvedMas).to.deep.equal([
+        ...stubs['_dnsaddr.ams-2.bootstrap.libp2p.io'].map(addr => multiaddr(addr.split('=').pop()))
+      ])
     })
 
     it('can resolve dnsaddr with bad record', async () => {
-      const ma = multiaddr('/dnsaddr/am6.bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
-
-      const stub = sinon.stub(Resolver.prototype, 'resolveTxt')
-      stub.onCall(0).returns(Promise.resolve(dnsaddrStub3))
+      const ma = multiaddr('/dnsaddr/bad-addrs.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb')
 
       // Resolve
-      const resolvedMas = await ma.resolve()
+      const resolvedMas = await ma.resolve({
+        dns
+      })
 
       // Should only have one address with the same peer id and should ignore the bad record
       expect(resolvedMas).to.have.lengthOf(1)
-      expect(resolvedMas[0].toString()).to.equal(ma.toString())
+      expect(resolvedMas[0].toString()).to.equal(stubs['_dnsaddr.am6.bootstrap.libp2p.io'][0].split('=').pop())
     })
 
     it('can cancel resolving', async () => {
@@ -131,7 +129,19 @@ describe('multiaddr resolve', () => {
 
       controller.abort()
 
-      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ECANCELLED')
+      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ABORT_ERR')
+    })
+
+    it('should abort resolving deeply nested records', async () => {
+      const ma = multiaddr('/dnsaddr/bootstrap.libp2p.io')
+
+      // Resolve
+      const resolvePromise = ma.resolve({
+        dns,
+        maxRecursiveDepth: 1
+      })
+
+      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ERR_MAX_RECURSIVE_DEPTH_REACHED')
     })
   })
 })

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { stubInterface, type StubbedInstance } from 'sinon-ts'
 import { multiaddr, resolvers } from '../src/index.js'
-import { dnsaddr } from '../src/resolvers/index.js'
+import { dnsaddrResolver } from '../src/resolvers/index.js'
 import type { DNS } from '@multiformats/dns'
 
 const stubs: Record<string, string[]> = {
@@ -60,7 +60,7 @@ describe('multiaddr resolve', () => {
       })
     })
 
-    resolvers.set('dnsaddr', dnsaddr)
+    resolvers.set('dnsaddr', dnsaddrResolver)
   })
 
   it('should throw if no resolver is available', async () => {


### PR DESCRIPTION
Accept a `DNS` instance from `@multiformats/dns` when resolving DNSADDR addresses.

Gives the user flexibility to control which DNS servers are used to resolve TXT records.