### PR TITLE
fix: remove unused dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,9 +169,8 @@
     "@chainsafe/is-ip": "^2.0.1",
     "@chainsafe/netmask": "^2.0.0",
     "@libp2p/interface": "^1.0.0",
-    "@multiformats/dns": "^1.0.1",
+    "@multiformats/dns": "^1.0.3",
     "multiformats": "^13.0.0",
-    "race-signal": "^1.0.2",
     "uint8-varint": "^2.0.1",
     "uint8arrays": "^5.0.0"
   },

--- a/src/resolvers/dnsaddr.ts
+++ b/src/resolvers/dnsaddr.ts
@@ -1,6 +1,5 @@
 import { CodeError } from '@libp2p/interface'
 import { dns, RecordType } from '@multiformats/dns'
-import { raceSignal } from 'race-signal'
 import { multiaddr } from '../index.js'
 import { getProtocol } from '../protocols-table.js'
 import type { Resolver } from './index.js'
@@ -25,7 +24,7 @@ export interface DNSADDROptions extends AbortOptions {
   maxRecursiveDepth?: number
 }
 
-export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddr (ma: Multiaddr, options: DNSADDROptions = {}): Promise<string[]> {
+export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddrResolver (ma: Multiaddr, options: DNSADDROptions = {}): Promise<string[]> {
   const recursionLimit = options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH
 
   if (recursionLimit === 0) {
@@ -35,12 +34,12 @@ export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddr 
   const [, hostname] = ma.stringTuples().find(([proto]) => proto === dnsaddrCode) ?? []
 
   const resolver = options?.dns ?? dns()
-  const result = await raceSignal(resolver.query(`_dnsaddr.${hostname}`, {
+  const result = await resolver.query(`_dnsaddr.${hostname}`, {
     signal: options?.signal,
     types: [
       RecordType.TXT
     ]
-  }), options.signal)
+  })
 
   const peerId = ma.getPeerId()
   const output: string[] = []

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -129,7 +129,7 @@ describe('multiaddr resolve', () => {
 
       controller.abort()
 
-      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ABORT_ERR')
+      await expect(resolvePromise).to.eventually.be.rejected()
     })
 
     it('should abort resolving deeply nested records', async () => {


### PR DESCRIPTION
No need to wrap the query in race signal, it supports abort signals.