### PR TITLE
fix: use named error instead of CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
   "dependencies": {
     "@chainsafe/is-ip": "^2.0.1",
     "@chainsafe/netmask": "^2.0.0",
-    "@libp2p/interface": "^1.0.0",
     "@multiformats/dns": "^1.0.3",
     "multiformats": "^13.0.0",
     "uint8-varint": "^2.0.1",

--- a/src/multiaddr.ts
+++ b/src/multiaddr.ts
@@ -12,7 +12,6 @@
  * ```
  */
 
-import { CodeError } from '@libp2p/interface'
 import { base58btc } from 'multiformats/bases/base58'
 import { CID } from 'multiformats/cid'
 import { equals as uint8ArrayEquals } from 'uint8arrays/equals'
@@ -31,6 +30,13 @@ const DNS_CODES = [
   getProtocol('dns6').code,
   getProtocol('dnsaddr').code
 ]
+
+class NoAvailableResolverError extends Error {
+  constructor (message = 'No available resolver') {
+    super(message)
+    this.name = 'NoAvailableResolverError'
+  }
+}
 
 /**
  * Creates a {@link Multiaddr} from a {@link MultiaddrInput}
@@ -232,7 +238,7 @@ export class Multiaddr implements MultiaddrInterface {
 
     const resolver = resolvers.get(resolvableProto.name)
     if (resolver == null) {
-      throw new CodeError(`no available resolver for ${resolvableProto.name}`, 'ERR_NO_AVAILABLE_RESOLVER')
+      throw new NoAvailableResolverError(`no available resolver for ${resolvableProto.name}`)
     }
 
     const result = await resolver(this, options)

--- a/src/resolvers/dnsaddr.ts
+++ b/src/resolvers/dnsaddr.ts
@@ -1,4 +1,3 @@
-import { CodeError } from '@libp2p/interface'
 import { dns, RecordType } from '@multiformats/dns'
 import { multiaddr } from '../index.js'
 import { getProtocol } from '../protocols-table.js'
@@ -8,6 +7,13 @@ import type { DNS } from '@multiformats/dns'
 
 const MAX_RECURSIVE_DEPTH = 32
 const { code: dnsaddrCode } = getProtocol('dnsaddr')
+
+class RecursionLimitError extends Error {
+  constructor (message = 'Max recursive depth reached') {
+    super(message)
+    this.name = 'RecursionLimitError'
+  }
+}
 
 export interface DNSADDROptions extends AbortOptions {
   /**
@@ -28,7 +34,7 @@ export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddrR
   const recursionLimit = options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH
 
   if (recursionLimit === 0) {
-    throw new CodeError('Max recursive depth reached', 'ERR_MAX_RECURSIVE_DEPTH_REACHED')
+    throw new RecursionLimitError('Max recursive depth reached')
   }
 
   const [, hostname] = ma.stringTuples().find(([proto]) => proto === dnsaddrCode) ?? []

--- a/test/resolvers.spec.ts
+++ b/test/resolvers.spec.ts
@@ -82,7 +82,7 @@ describe('multiaddr resolve', () => {
 
     // Resolve
     await expect(ma.resolve()).to.eventually.be.rejected()
-      .and.to.have.property('code', 'ERR_NO_AVAILABLE_RESOLVER')
+      .and.to.have.property('name', 'NoAvailableResolverError')
   })
 
   describe('dnsaddr', () => {
@@ -153,7 +153,7 @@ describe('multiaddr resolve', () => {
         maxRecursiveDepth: 1
       })
 
-      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ERR_MAX_RECURSIVE_DEPTH_REACHED')
+      await expect(resolvePromise).to.eventually.be.rejected().with.property('name', 'RecursionLimitError')
     })
 
     it('should handle recursive loops', async () => {
@@ -165,7 +165,7 @@ describe('multiaddr resolve', () => {
         maxRecursiveDepth: 1
       })
 
-      await expect(resolvePromise).to.eventually.be.rejected().with.property('code', 'ERR_MAX_RECURSIVE_DEPTH_REACHED')
+      await expect(resolvePromise).to.eventually.be.rejected().with.property('name', 'RecursionLimitError')
     })
 
     it('should handle double quotes', async () => {


### PR DESCRIPTION
`CodeError` is going away in the next libp2p release so use a named error instead.