### PR TITLE
fix: do not allow modifying tuples

### DIFF
--- a/src/multiaddr.ts
+++ b/src/multiaddr.ts
@@ -151,11 +151,23 @@ export class Multiaddr implements MultiaddrInterface {
   }
 
   tuples (): Array<[number, Uint8Array?]> {
-    return this.#tuples
+    return this.#tuples.map(([code, value]) => {
+      if (value == null) {
+        return [code]
+      }
+
+      return [code, value]
+    })
   }
 
   stringTuples (): Array<[number, string?]> {
-    return this.#stringTuples
+    return this.#stringTuples.map(([code, value]) => {
+      if (value == null) {
+        return [code]
+      }
+
+      return [code, value]
+    })
   }
 
   encapsulate (addr: MultiaddrInput): Multiaddr {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -731,6 +731,14 @@ describe('helpers', () => {
           [302]
         ])
     })
+
+    it('does not allow modifying parts', () => {
+      const ma = multiaddr('/ip4/0.0.0.0/tcp/1234')
+      const tuples = ma.tuples()
+      tuples[0][0] = 41
+
+      expect(ma.toOptions()).to.have.property('family', 4)
+    })
   })
 
   describe('.stringTuples', () => {
@@ -740,6 +748,14 @@ describe('helpers', () => {
           [4, '0.0.0.0'],
           [302]
         ])
+    })
+
+    it('does not allow modifying string parts', () => {
+      const ma = multiaddr('/ip4/0.0.0.0/tcp/1234')
+      const tuples = ma.stringTuples()
+      tuples[0][0] = 41
+
+      expect(ma.toOptions()).to.have.property('family', 4)
     })
   })
 


### PR DESCRIPTION
Return a clone of the string/tuple list to prevent external modification of internal state.