### PR TITLE
feat: add fromTuples and fromStringTuples methods

### DIFF
--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1,6 +1,5 @@
 import * as varint from 'uint8-varint'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { convertToBytes, convertToString } from './convert.js'
 import { getProtocol } from './protocols-table.js'

--- a/src/codec.ts
+++ b/src/codec.ts
@@ -1,5 +1,6 @@
 import * as varint from 'uint8-varint'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { convertToBytes, convertToString } from './convert.js'
 import { getProtocol } from './protocols-table.js'
@@ -124,7 +125,26 @@ export function bytesToMultiaddrParts (bytes: Uint8Array): MultiaddrParts {
 }
 
 /**
- * [[str name, str addr]... ] -> string
+ * [[num code, str value?]... ] -> Tuple[]
+ */
+export function stringTuplesToTuples (stringTuples: StringTuple[]): Tuple[] {
+  const tuples: Tuple[] = []
+
+  stringTuples.forEach(([code, value]) => {
+    const tuple: Tuple = [code]
+
+    if (value != null) {
+      tuple[1] = convertToBytes(code, value)
+    }
+
+    tuples.push(tuple)
+  })
+
+  return tuples
+}
+
+/**
+ * [[num code, str value?]... ] -> string
  */
 function stringTuplesToString (tuples: StringTuple[]): string {
   const parts: string[] = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,7 @@
  * ```
  */
 
+import { stringTuplesToTuples, tuplesToBytes } from './codec.js'
 import { Multiaddr as MultiaddrClass, symbol } from './multiaddr.js'
 import { getProtocol } from './protocols-table.js'
 import type { Resolver } from './resolvers/index.js'
@@ -524,6 +525,48 @@ export function fromNodeAddress (addr: NodeAddress, transport: string): Multiadd
       throw Error('Invalid addr family, should be 4 or 6.')
   }
   return new MultiaddrClass('/' + [ip, host, transport, addr.port].join('/'))
+}
+
+/**
+ * Create a {@link Multiaddr} from an array of {@link Tuple}s
+ *
+ * @example
+ *
+ * ```ts
+ * import { fromTuples, multiaddr } from '@multiformats/multiaddr'
+ *
+ * const ma = multiaddr('/ip4/127.0.0.1')
+ * const tuples = ma.tuples()
+ *
+ * const ma2 = fromTuples(tuples)
+ *
+ * console.info(ma2)
+ * // '/ip4/127.0.0.1'
+ * ```
+ */
+export function fromTuples (tuples: Tuple[]): Multiaddr {
+  return multiaddr(tuplesToBytes(tuples))
+}
+
+/**
+ * Create a {@link Multiaddr} from an array of {@link StringTuple}s
+ *
+ * @example
+ *
+ * ```ts
+ * import { fromStringTuples, multiaddr } from '@multiformats/multiaddr'
+ *
+ * const ma = multiaddr('/ip4/127.0.0.1')
+ * const tuples = ma.stringTuples()
+ *
+ * const ma2 = fromStringTuples(tuples)
+ *
+ * console.info(ma2)
+ * // '/ip4/127.0.0.1'
+ * ```
+ */
+export function fromStringTuples (tuples: StringTuple[]): Multiaddr {
+  return fromTuples(stringTuplesToTuples(tuples))
 }
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,7 +2,7 @@
 /* eslint-env mocha */
 import { expect } from 'aegir/chai'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { multiaddr, isMultiaddr, fromNodeAddress, isName } from '../src/index.js'
+import { multiaddr, isMultiaddr, fromNodeAddress, isName, fromTuples, fromStringTuples } from '../src/index.js'
 import { codes } from '../src/protocols-table.js'
 import type { Multiaddr } from '../src/index.js'
 
@@ -946,6 +946,28 @@ describe('helpers', () => {
       ).to.be.eql(
         '/ip6zone/x/ip6/fe80::1/tcp/1234'
       )
+    })
+  })
+
+  describe('.fromTuples', () => {
+    it('should create a multiaddr from a list of tuples', () => {
+      const ma = multiaddr('/ip4/0.0.0.0')
+      const tuples = ma.tuples()
+      tuples.push([0x06, Uint8Array.from([0, 100])])
+
+      const ma2 = fromTuples(tuples)
+      expect(ma2.toString()).to.equal('/ip4/0.0.0.0/tcp/100')
+    })
+  })
+
+  describe('.fromStringTuples', () => {
+    it('should create a multiaddr from a list of string tuples', () => {
+      const ma = multiaddr('/ip4/0.0.0.0')
+      const tuples = ma.stringTuples()
+      tuples.push([0x06, '100'])
+
+      const ma2 = fromStringTuples(tuples)
+      expect(ma2.toString()).to.equal('/ip4/0.0.0.0/tcp/100')
     })
   })
 


### PR DESCRIPTION
Adds methods to create Multiaddr instances from arrays of tuples so it's possible to insert tuples into Multiaddrs without having to stringify/parse them