### PR TITLE
feat: registerProtocol

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@
 
 import { stringTuplesToTuples, tuplesToBytes } from './codec.js'
 import { Multiaddr as MultiaddrClass, symbol } from './multiaddr.js'
-import { getProtocol } from './protocols-table.js'
+import { getProtocol, registerProtocol } from './protocols-table.js'
 import type { Resolver } from './resolvers/index.js'
 import type { DNS } from '@multiformats/dns'
 
@@ -627,4 +627,4 @@ export function multiaddr (addr?: MultiaddrInput): Multiaddr {
   return new MultiaddrClass(addr)
 }
 
-export { getProtocol as protocols }
+export { getProtocol as protocols, registerProtocol }

--- a/src/protocols-table.ts
+++ b/src/protocols-table.ts
@@ -96,3 +96,8 @@ export function getProtocol (proto: number | string): Protocol {
 
   throw new Error(`invalid protocol id type: ${typeof proto}`)
 }
+
+export function registerProtocol (protocol: Protocol): void {
+  codes[protocol.code] = protocol
+  names[protocol.name] = protocol
+}


### PR DESCRIPTION
related: #310

In golang, can register a protocol, but js has no way to use its own protocol.

Implement registerProtocol.