### PR TITLE
fix: deprecate DNS resolvers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -672,6 +672,8 @@ export function fromNodeAddress (addr: NodeAddress, transport: string): Multiadd
  * console.info(ma2)
  * // '/ip4/127.0.0.1'
  * ```
+ *
+ * @deprecated Will be removed in a future release
  */
 export function fromTuples (tuples: Tuple[]): Multiaddr {
   return multiaddr(tuples.map(([code, value]) => {
@@ -706,6 +708,8 @@ export function fromTuples (tuples: Tuple[]): Multiaddr {
  * console.info(ma2)
  * // '/ip4/127.0.0.1'
  * ```
+ *
+ * @deprecated Will be removed in a future release
  */
 export function fromStringTuples (tuples: StringTuple[]): Multiaddr {
   return multiaddr(tuples.map(([code, value]) => {
@@ -737,6 +741,8 @@ export function fromStringTuples (tuples: StringTuple[]): Multiaddr {
  * isName(multiaddr('/dns/ipfs.io'))
  * // true
  * ```
+ *
+ * @deprecated DNS resolving will be removed in a future release
  */
 export function isName (addr: Multiaddr): boolean {
   if (!isMultiaddr(addr)) {

--- a/src/resolvers/dnsaddr.ts
+++ b/src/resolvers/dnsaddr.ts
@@ -15,6 +15,9 @@ class RecursionLimitError extends Error {
   }
 }
 
+/**
+ * @deprecated DNS resolving will be removed in a future release
+ */
 export interface DNSADDROptions extends AbortOptions {
   /**
    * An optional DNS resolver
@@ -30,6 +33,9 @@ export interface DNSADDROptions extends AbortOptions {
   maxRecursiveDepth?: number
 }
 
+/**
+ * @deprecated DNS resolving will be removed in a future release
+ */
 export const dnsaddrResolver: Resolver<DNSADDROptions> = async function dnsaddrResolver (ma: Multiaddr, options: DNSADDROptions = {}): Promise<string[]> {
   const recursionLimit = options.maxRecursiveDepth ?? MAX_RECURSIVE_DEPTH
 

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,5 +1,8 @@
 import type { AbortOptions, Multiaddr } from '../index.js'
 
+/**
+ * @deprecated DNS resolving will be removed in a future release
+ */
 export interface Resolver<ResolveOptions extends AbortOptions = AbortOptions> {
   (ma: Multiaddr, options?: ResolveOptions): Promise<string[]>
 }


### PR DESCRIPTION
Adds deprecation notices to all DNS resolvers. This is so this module can become more lightweight in a future release.