### PR TITLE
fix: return deep copy of components

### DIFF
--- a/src/multiaddr.ts
+++ b/src/multiaddr.ts
@@ -86,7 +86,7 @@ export class Multiaddr implements MultiaddrInterface {
 
   getComponents (): Component[] {
     return [
-      ...this.#components
+      ...this.#components.map(c => ({ ...c }))
     ]
   }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -423,6 +423,14 @@ describe('.getComponents', () => {
 
     expect(ma.getComponents()).to.have.nested.property('[0].code', CODE_IP4)
   })
+
+  it('does not allow modifying individual parts', () => {
+    const ma = multiaddr('/ip4/0.0.0.0/tcp/1234')
+    const components = ma.getComponents()
+    components[0].value = '1.1.1.1'
+
+    expect(ma.getComponents()).to.have.nested.property('[0].value', '0.0.0.0')
+  })
 })
 
 describe('.decapsulate', () => {


### PR DESCRIPTION
To prevent indiviual multiaddr components being modified, return a deep copy of the components list instead of a shallow one.