### PR TITLE
fix: export registry as interface instance

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -106,7 +106,7 @@ class Registry implements RegistryInterface {
   }
 }
 
-export const registry = new Registry()
+export const registry: RegistryInterface = new Registry()
 
 const codecs: ProtocolCodec[] = [{
   code: CODE_IP4,


### PR DESCRIPTION
Ensures the doc generation assigns the correct type to the exported variable.